### PR TITLE
feat: added auto-preconditions

### DIFF
--- a/src/lib/errors/Identifiers.ts
+++ b/src/lib/errors/Identifiers.ts
@@ -35,6 +35,8 @@ export const enum Identifiers {
 	PreconditionCooldown = 'preconditionCooldown',
 	PreconditionDMOnly = 'preconditionDmOnly',
 	PreconditionGuildOnly = 'preconditionGuildOnly',
+	PreconditionNewsOnly = 'preconditionNewsOnly',
 	PreconditionNSFW = 'preconditionNsfw',
-	PreconditionPermissions = 'preconditionPermissions'
+	PreconditionPermissions = 'preconditionPermissions',
+	PreconditionTextOnly = 'preconditionTextOnly'
 }

--- a/src/lib/structures/ExtendedArgument.ts
+++ b/src/lib/structures/ExtendedArgument.ts
@@ -66,7 +66,7 @@ export abstract class ExtendedArgument<K extends keyof ArgType, T> extends Argum
 	}
 
 	public async run(parameter: string, context: ArgumentContext<T>): AsyncArgumentResult<T> {
-		const result = await this.base.run(parameter, (context as unknown) as ArgumentContext<ArgType[K]>);
+		const result = await this.base.run(parameter, context as unknown as ArgumentContext<ArgType[K]>);
 		// If the result was successful (i.e. is of type `Ok<ArgType[K]>`), pass its
 		// value to [[ExtendedArgument#handle]] for further parsing. Otherwise, return
 		// the error as is; it'll provide contextual information from the base argument.

--- a/src/lib/structures/StoreRegistry.ts
+++ b/src/lib/structures/StoreRegistry.ts
@@ -66,7 +66,7 @@ export class StoreRegistry extends Collection<Key, Value> {
 	 * @param store The store to register.
 	 */
 	public register<T extends Piece>(store: Store<T>): this {
-		this.set(store.name as Key, (store as unknown) as Value);
+		this.set(store.name as Key, store as unknown as Value);
 		return this;
 	}
 

--- a/src/lib/utils/preconditions/PreconditionContainerArray.ts
+++ b/src/lib/utils/preconditions/PreconditionContainerArray.ts
@@ -13,7 +13,7 @@ import { PreconditionContainerSingle, PreconditionSingleResolvable } from './Pre
  */
 export const enum PreconditionRunMode {
 	/**
-	 * The entries are run sequentially, this is the default behavior and can be slow when doing long asynchronous
+	 * The entries are run sequentially, this is the default behaviour and can be slow when doing long asynchronous
 	 * tasks, but is performance savvy.
 	 * @since 1.0.0
 	 */

--- a/src/lib/utils/preconditions/PreconditionContainerArray.ts
+++ b/src/lib/utils/preconditions/PreconditionContainerArray.ts
@@ -13,7 +13,7 @@ import { PreconditionContainerSingle, PreconditionSingleResolvable } from './Pre
  */
 export const enum PreconditionRunMode {
 	/**
-	 * The entries are run sequentially, this is the default behaviour and can be slow when doing long asynchronous
+	 * The entries are run sequentially, this is the default behavior and can be slow when doing long asynchronous
 	 * tasks, but is performance savvy.
 	 * @since 1.0.0
 	 */

--- a/src/preconditions/NewsOnly.ts
+++ b/src/preconditions/NewsOnly.ts
@@ -1,0 +1,11 @@
+import type { Message } from 'discord.js';
+import { Identifiers } from '../lib/errors/Identifiers';
+import { Precondition, PreconditionResult } from '../lib/structures/Precondition';
+
+export class CorePrecondition extends Precondition {
+	public run(message: Message): PreconditionResult {
+		return message.channel.type === 'news'
+			? this.error({ identifier: Identifiers.PreconditionNewsOnly, message: 'You can only run this command in news channels.' })
+			: this.ok();
+	}
+}

--- a/src/preconditions/TextOnly.ts
+++ b/src/preconditions/TextOnly.ts
@@ -1,0 +1,11 @@
+import type { Message } from 'discord.js';
+import { Identifiers } from '../lib/errors/Identifiers';
+import { Precondition, PreconditionResult } from '../lib/structures/Precondition';
+
+export class CorePrecondition extends Precondition {
+	public run(message: Message): PreconditionResult {
+		return message.channel.type === 'text'
+			? this.error({ identifier: Identifiers.PreconditionTextOnly, message: 'You can only run this command in text channels.' })
+			: this.ok();
+	}
+}


### PR DESCRIPTION
- feat(command): added auto-preconditions
- feat(command): added `CommandOptions.nsfw`
- feat(command): added `CommandOptions.cooldownBucket`
- feat(command): added `CommandOptions.cooldownDuration`
- feat(command): added `CommandOptions.runIn`
- feat(identifiers): added `Identifiers.PreconditionNewsOnly`
- feat(identifiers): added `Identifiers.PreconditionTextOnly`
- BREAKING CHANGE: refactor(command): force array in `CommandOptions.preconditions`

> **Note**: `CommandOptions.permissions` has not been added because it's too tied to discord.js, an alternative approach which allows us to go library agnostic will be available later.
