### PR TITLE
fix(NonePrefixedMessage): rename to NonPrefixedMessage

### DIFF
--- a/src/events/command-handler/CoreMessageParser.ts
+++ b/src/events/command-handler/CoreMessageParser.ts
@@ -33,7 +33,7 @@ export class CoreEvent extends Event<Events.PreMessageParsed> {
 			if (parsed !== null) prefix = parsed;
 		}
 
-		if (prefix === null) client.emit(Events.NonePrefixedMessage, message);
+		if (prefix === null) client.emit(Events.NonPrefixedMessage, message);
 		else client.emit(Events.PrefixedMessage, message, prefix);
 	}
 

--- a/src/lib/types/Events.ts
+++ b/src/lib/types/Events.ts
@@ -77,7 +77,7 @@ export enum Events {
 	CommandFinish = 'commandFinish',
 	CommandError = 'commandError',
 	PluginLoaded = 'pluginLoaded',
-	NonePrefixedMessage = 'nonePrefixedMessage'
+	NonPrefixedMessage = 'nonPrefixedMessage'
 	// #endregion Sapphire load cycle events
 }
 
@@ -149,7 +149,7 @@ declare module 'discord.js' {
 		[Events.CommandError]: [error: Error, payload: CommandErrorPayload];
 		[Events.CommandFinish]: [message: Message, command: Command, payload: CommandFinishPayload];
 		[Events.PluginLoaded]: [hook: PluginHook, name: string | undefined];
-		[Events.NonePrefixedMessage]: [message: Message];
+		[Events.NonPrefixedMessage]: [message: Message];
 		// #endregion Sapphire load cycle events
 
 		// #region Termination


### PR DESCRIPTION
Renamed `NonePrefixedMessage` to `NonPrefixedMessage`.