### PR TITLE
feat: stricter types for preconditions

### DIFF
--- a/src/lib/structures/Precondition.ts
+++ b/src/lib/structures/Precondition.ts
@@ -1,9 +1,10 @@
 import { Piece, PieceContext, PieceOptions } from '@sapphire/pieces';
 import type { Awaited } from '@sapphire/utilities';
-import type { Message } from 'discord.js';
+import type { Message, Permissions } from 'discord.js';
 import { PreconditionError } from '../errors/PreconditionError';
 import type { UserError } from '../errors/UserError';
 import { err, ok, Result } from '../parsers/Result';
+import type { BucketScope } from '../types/Enums';
 import type { Command } from './Command';
 
 export type PreconditionResult = Awaited<Result<unknown, UserError>>;
@@ -31,6 +32,75 @@ export abstract class Precondition extends Piece {
 		return err(new PreconditionError({ precondition: this, ...options }));
 	}
 }
+
+/**
+ * The registered preconditions and their contexts, if any. When registering new ones, it is recommended to use
+ * [module augmentation](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation) so
+ * custom ones are registered.
+ *
+ * When a key's value is `never`, it means that it does not take any context, which allows you to pass its identifier as
+ * a bare string (e.g. `preconditions: ['NSFW']`), however, if context is required, a non-`never` type should be passed,
+ * which will type {@link PreconditionContainerArray#append} and require an object with the name and a `context` with
+ * the defined type.
+ *
+ * @example
+ * ```typescript
+ * declare module '@sapphire/framework' {
+ *   interface Preconditions {
+ *     // A precondition named `Moderator` which does not read `context`:
+ *     Moderator: never;
+ *
+ *     // A precondition named `ChannelPermissions` which does read `context`:
+ *     ChannelPermissions: {
+ *       permissions: Permissions;
+ *     };
+ *   }
+ * }
+ *
+ * // [✔] These are valid:
+ * preconditions.append('Moderator');
+ * preconditions.append({ name: 'Moderator' });
+ * preconditions.append({
+ *   name: 'ChannelPermissions',
+ *   context: { permissions: new Permissions(8) }
+ * });
+ *
+ * // [X] These are invalid:
+ * preconditions.append({ name: 'Moderator', context: {} });
+ * // ➡ `never` keys do not accept `context`.
+ *
+ * preconditions.append('ChannelPermissions');
+ * // ➡ non-`never` keys always require `context`, a string cannot be used.
+ *
+ * preconditions.append({
+ *   name: 'ChannelPermissions',
+ *   context: { unknownProperty: 1 }
+ * });
+ * // ➡ mismatching `context` properties, `{ unknownProperty: number }` is not
+ * // assignable to `{ permissions: Permissions }`.
+ * ```
+ */
+export interface Preconditions {
+	Cooldown: {
+		scope: BucketScope;
+		delay: number;
+		limit: number;
+	};
+	DMOnly: never;
+	Enabled: never;
+	GuildOnly: never;
+	NewsOnly: never;
+	NSFW: never;
+	Permissions: {
+		permissions: Permissions;
+	};
+	TextOnly: never;
+}
+
+export type PreconditionKeys = keyof Preconditions;
+export type SimplePreconditionKeys = {
+	[K in PreconditionKeys]: Preconditions[K] extends never ? K : never;
+}[PreconditionKeys];
 
 export interface PreconditionOptions extends PieceOptions {
 	/**

--- a/src/lib/types/Enums.ts
+++ b/src/lib/types/Enums.ts
@@ -13,23 +13,23 @@ export const enum PluginHook {
 }
 
 /**
- * The level the cooldown applies to
+ * The scope the cooldown applies to.
  */
-export const enum BucketType {
+export const enum BucketScope {
 	/**
-	 * Per channel cooldowns
+	 * Per channel cooldowns.
 	 */
 	Channel,
 	/**
-	 * Global cooldowns
+	 * Global cooldowns.
 	 */
 	Global,
 	/**
-	 * Per guild cooldowns
+	 * Per guild cooldowns.
 	 */
 	Guild,
 	/**
-	 * Per user cooldowns
+	 * Per user cooldowns.
 	 */
 	User
 }

--- a/src/lib/utils/preconditions/PreconditionContainerArray.ts
+++ b/src/lib/utils/preconditions/PreconditionContainerArray.ts
@@ -1,11 +1,16 @@
 import { Collection, Message } from 'discord.js';
 import type { Command } from '../../structures/Command';
-import type { PreconditionContext } from '../../structures/Precondition';
+import type { PreconditionContext, PreconditionKeys, SimplePreconditionKeys } from '../../structures/Precondition';
 import type { IPreconditionCondition } from './conditions/IPreconditionCondition';
 import { PreconditionConditionAnd } from './conditions/PreconditionConditionAnd';
 import { PreconditionConditionOr } from './conditions/PreconditionConditionOr';
 import type { IPreconditionContainer, PreconditionContainerReturn } from './IPreconditionContainer';
-import { PreconditionContainerSingle, PreconditionSingleResolvable } from './PreconditionContainerSingle';
+import {
+	PreconditionContainerSingle,
+	PreconditionSingleResolvable,
+	PreconditionSingleResolvableDetails,
+	SimplePreconditionSingleResolvableDetails
+} from './PreconditionContainerSingle';
 
 /**
  * The run mode for a {@link PreconditionContainerArray}.
@@ -143,6 +148,13 @@ export class PreconditionContainerArray implements IPreconditionContainer {
 	 */
 	public add(entry: IPreconditionContainer): this {
 		this.entries.push(entry);
+		return this;
+	}
+
+	public append(keyOrEntries: SimplePreconditionSingleResolvableDetails | SimplePreconditionKeys | PreconditionContainerArray): this;
+	public append<K extends PreconditionKeys>(entry: PreconditionSingleResolvableDetails<K>): this;
+	public append(entry: PreconditionContainerArray | PreconditionSingleResolvable): this {
+		this.entries.push(entry instanceof PreconditionContainerArray ? entry : new PreconditionContainerSingle(entry));
 		return this;
 	}
 

--- a/src/lib/utils/preconditions/PreconditionContainerSingle.ts
+++ b/src/lib/utils/preconditions/PreconditionContainerSingle.ts
@@ -1,33 +1,46 @@
 import { container } from '@sapphire/pieces';
 import type { Message } from 'discord.js';
 import type { Command } from '../../structures/Command';
-import type { PreconditionContext } from '../../structures/Precondition';
+import type { PreconditionContext, PreconditionKeys, Preconditions, SimplePreconditionKeys } from '../../structures/Precondition';
 import type { IPreconditionContainer } from './IPreconditionContainer';
+
+/**
+ * Defines the simple options for the {@link PreconditionContainerSingle}, where only the name of the precondition can
+ * be defined.
+ * @since 2.0.0
+ */
+export interface SimplePreconditionSingleResolvableDetails {
+	/**
+	 * The name of the precondition to retrieve from {@link SapphireClient.preconditions}.
+	 * @since 2.0.0
+	 */
+	name: SimplePreconditionKeys;
+}
 
 /**
  * Defines the detailed options for the {@link PreconditionContainerSingle}, where both the {@link PreconditionContext} and the
  * name of the precondition can be defined.
  * @since 1.0.0
  */
-export interface PreconditionSingleResolvableDetails {
+export interface PreconditionSingleResolvableDetails<K extends PreconditionKeys = PreconditionKeys> {
 	/**
 	 * The name of the precondition to retrieve from {@link SapphireClient.preconditions}.
 	 * @since 1.0.0
 	 */
-	name: string;
+	name: K;
 
 	/**
 	 * The context to be set at {@link PreconditionContainerSingle.context}.
 	 * @since 1.0.0
 	 */
-	context: Record<PropertyKey, unknown>;
+	context: Preconditions[K];
 }
 
 /**
  * Defines the data accepted by {@link PreconditionContainerSingle}'s constructor.
  * @since 1.0.0
  */
-export type PreconditionSingleResolvable = string | PreconditionSingleResolvableDetails;
+export type PreconditionSingleResolvable = SimplePreconditionKeys | SimplePreconditionSingleResolvableDetails | PreconditionSingleResolvableDetails;
 
 /**
  * An {@link IPreconditionContainer} which runs a single precondition from {@link SapphireClient.preconditions}.
@@ -53,7 +66,7 @@ export class PreconditionContainerSingle implements IPreconditionContainer {
 			this.context = {};
 			this.name = data;
 		} else {
-			this.context = data.context;
+			this.context = Reflect.get(data, 'context') ?? {};
 			this.name = data.name;
 		}
 	}

--- a/src/lib/utils/preconditions/containers/PermissionsPrecondition.ts
+++ b/src/lib/utils/preconditions/containers/PermissionsPrecondition.ts
@@ -22,9 +22,9 @@ import type { PreconditionSingleResolvableDetails } from '../PreconditionContain
  * }
  * ```
  */
-export class PermissionsPrecondition implements PreconditionSingleResolvableDetails {
-	public name: string;
-	public context: Record<PropertyKey, unknown>;
+export class PermissionsPrecondition implements PreconditionSingleResolvableDetails<'Permissions'> {
+	public name: 'Permissions';
+	public context: { permissions: Permissions };
 
 	/**
 	 * Constructs a precondition container entry.

--- a/src/preconditions/Cooldown.ts
+++ b/src/preconditions/Cooldown.ts
@@ -3,10 +3,10 @@ import type { Message } from 'discord.js';
 import { Identifiers } from '../lib/errors/Identifiers';
 import type { Command } from '../lib/structures/Command';
 import { Precondition, PreconditionContext } from '../lib/structures/Precondition';
-import { BucketType } from '../lib/types/Enums';
+import { BucketScope } from '../lib/types/Enums';
 
 export interface CooldownContext extends PreconditionContext {
-	bucketType?: BucketType;
+	scope?: BucketScope;
 	delay?: number;
 	limit?: number;
 }
@@ -34,12 +34,12 @@ export class CorePrecondition extends Precondition {
 	}
 
 	private getID(message: Message, context: CooldownContext) {
-		switch (context.bucketType) {
-			case BucketType.Global:
+		switch (context.scope) {
+			case BucketScope.Global:
 				return 'global';
-			case BucketType.Channel:
+			case BucketScope.Channel:
 				return message.channel.id;
-			case BucketType.Guild:
+			case BucketScope.Guild:
 				return message.guild!.id;
 			default:
 				return message.author.id;

--- a/src/preconditions/Permissions.ts
+++ b/src/preconditions/Permissions.ts
@@ -18,9 +18,9 @@ export class CorePrecondition extends Precondition {
 
 	public run(message: Message, _command: Command, context: PreconditionContext): PreconditionResult {
 		const required = (context.permissions as Permissions) ?? new Permissions(0);
-		const permissions = message.guild
-			? (message.channel as TextChannel | NewsChannel).permissionsFor(message.client.id!)!
-			: this.dmChannelPermissions;
+		const channel = message.channel as TextChannel | NewsChannel;
+
+		const permissions = message.guild ? channel.permissionsFor(message.client.id!)! : this.dmChannelPermissions;
 		const missing = permissions.missing(required);
 		return missing.length === 0
 			? this.ok()


### PR DESCRIPTION
- Added `Command#parseConstructorPreConditions`.
- Added `Command#parseConstructorPreConditionsRunIn`.
- Added `Command#parseConstructorPreConditionsNsfw`.
- Added `Command#parseConstructorPreConditionsRequiredClientPermissions`.
- Added `Command#parseConstructorPreConditionsCooldown`.
- Added `CommandPreConditions.Permissions`.
- Added `CommandOptions.cooldownScope`.
- Added `CommandOptions.requiredClientPermissions`.
- Added `Preconditions` interface, this strict types all precondition names and contexts.
- Added `PreconditionContainerArray#append`.
- Added `SimplePreconditionSingleResolvableDetails`.
- Fixed cooldown precondition not working when defining alias properties from `Command`.
- :warning: BREAKING CHANGE: Changed `Command#preconditions` to `PreconditionContainerArray`.
- :warning: BREAKING CHANGE: Removed `Command#resolveConstructorPreConditions`.
- :warning: BREAKING CHANGE: Renamed `CommandOptions.cooldownBucket` to `cooldownLimit`.
- :warning: BREAKING CHANGE: Renamed `CommandOptions.cooldownDuration` to `cooldownDelay`.
- :warning: BREAKING CHANGE: Renamed `BucketType` to `BucketScope`.
- :warning: BREAKING CHANGE: Changed `PreconditionSingleResolvableDetails` to take a type parameter.
- :warning: BREAKING CHANGE: Changed `PreconditionSingleResolvable` to use `Preconditions`'s type.
- :warning: BREAKING CHANGE: Renamed `CooldownContext.bucketType` to `scope`.
