### PR TITLE
refactor(types): rename EventOptions to ListenerOptions

### DIFF
--- a/src/lib/structures/Listener.ts
+++ b/src/lib/structures/Listener.ts
@@ -62,7 +62,7 @@ export abstract class Listener<E extends keyof ClientEvents | symbol = ''> exten
 	public readonly once: boolean;
 	private _listener: ((...args: any[]) => void) | null;
 
-	public constructor(context: PieceContext, options: EventOptions = {}) {
+	public constructor(context: PieceContext, options: ListenerOptions = {}) {
 		super(context, options);
 
 		this.emitter =
@@ -131,7 +131,7 @@ export abstract class Listener<E extends keyof ClientEvents | symbol = ''> exten
 	}
 }
 
-export interface EventOptions extends PieceOptions {
+export interface ListenerOptions extends PieceOptions {
 	readonly emitter?: keyof Client | EventEmitter;
 	readonly event?: string;
 	readonly once?: boolean;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/55610086/126878963-28eb907c-3bd9-43ea-af53-d564e7dd0c44.png)

With the migration to using `Listener` instead of events, the type for `EventOptions` was missed, and this PR fixes those types.

In addition to this, I scanned the repository for additional mentions of the `EventOptions` and `Event` in general, and did not find anything.