### PR TITLE
fix(CoreMessageParser): lowercase channel type

### DIFF
--- a/src/listeners/command-handler/CoreMessageParser.ts
+++ b/src/listeners/command-handler/CoreMessageParser.ts
@@ -38,7 +38,7 @@ export class CoreListener extends Listener<typeof Events.PreMessageParsed> {
 	}
 
 	private async canRunInChannel(message: Message): Promise<boolean> {
-		if (message.channel.type === 'DM') return true;
+		if (message.channel.type === 'dm') return true;
 
 		const me = message.guild!.me ?? (message.client.id ? await message.guild!.members.fetch(message.client.id) : null);
 		if (!me) return false;


### PR DESCRIPTION
On `CoreMessageParser#canRunInChannel`, the type is uppercased while, on the actual discord.js' version (13.1.0), it is returned as a lowercased name, and thus never returns true. Then, when it tries to get `message.guild!.me`, `guild` property will be `undefined` and will attempt to access property `me` of `undefined` (or `null`?).

This makes impossible to accept DM commands.