### PR TITLE
feat(cooldown): add `cooldownFilteredUsers` to exempt users from the cooldown precondition

### DIFF
--- a/src/lib/structures/Command.ts
+++ b/src/lib/structures/Command.ts
@@ -1,6 +1,6 @@
 import { AliasPiece, AliasPieceOptions, PieceContext } from '@sapphire/pieces';
 import { Awaited, isNullish } from '@sapphire/utilities';
-import { Message, PermissionResolvable, Permissions } from 'discord.js';
+import { Message, PermissionResolvable, Permissions, Snowflake } from 'discord.js';
 import * as Lexure from 'lexure';
 import { Args } from '../parsers/Args';
 import { BucketScope } from '../types/Enums';
@@ -154,10 +154,12 @@ export abstract class Command<T = Args> extends AliasPiece {
 	protected parseConstructorPreConditionsCooldown(options: CommandOptions) {
 		const limit = options.cooldownLimit ?? 1;
 		const delay = options.cooldownDelay ?? 0;
+		const filteredUsers = options.cooldownFilteredUsers;
+
 		if (limit && delay) {
 			this.preconditions.append({
 				name: CommandPreConditions.Cooldown,
-				context: { scope: options.cooldownScope ?? BucketScope.User, limit, delay }
+				context: { scope: options.cooldownScope ?? BucketScope.User, limit, delay, filteredUsers }
 			});
 		}
 	}
@@ -343,6 +345,14 @@ export interface CommandOptions extends AliasPieceOptions, FlagStrategyOptions {
 	 * @default BucketScope.User
 	 */
 	cooldownScope?: BucketScope;
+
+	/**
+	 * The users that are exempt from the Cooldown precondition.
+	 * Use this to filter out someone like a bot owner
+	 * @since 2.0.0
+	 * @default undefined
+	 */
+	cooldownFilteredUsers?: Snowflake[];
 
 	/**
 	 * The required permissions for the client.

--- a/src/lib/structures/Precondition.ts
+++ b/src/lib/structures/Precondition.ts
@@ -1,10 +1,10 @@
 import { Piece, PieceContext, PieceOptions } from '@sapphire/pieces';
 import type { Awaited } from '@sapphire/utilities';
 import type { Message, Permissions } from 'discord.js';
+import type { CooldownContext } from '../../preconditions/Cooldown';
 import { PreconditionError } from '../errors/PreconditionError';
 import type { UserError } from '../errors/UserError';
 import { err, ok, Result } from '../parsers/Result';
-import type { BucketScope } from '../types/Enums';
 import type { Command } from './Command';
 
 export type PreconditionResult = Awaited<Result<unknown, UserError>>;
@@ -81,11 +81,7 @@ export abstract class Precondition extends Piece {
  * ```
  */
 export interface Preconditions {
-	Cooldown: {
-		scope?: BucketScope;
-		delay: number;
-		limit?: number;
-	};
+	Cooldown: CooldownContext;
 	DMOnly: never;
 	Enabled: never;
 	GuildNewsOnly: never;

--- a/src/preconditions/Cooldown.ts
+++ b/src/preconditions/Cooldown.ts
@@ -1,5 +1,5 @@
 import { RateLimitManager } from '@sapphire/ratelimits';
-import type { Message } from 'discord.js';
+import type { Message, Snowflake } from 'discord.js';
 import { Identifiers } from '../lib/errors/Identifiers';
 import type { Command } from '../lib/structures/Command';
 import { Precondition, PreconditionContext } from '../lib/structures/Precondition';
@@ -9,6 +9,7 @@ export interface CooldownContext extends PreconditionContext {
 	scope?: BucketScope;
 	delay: number;
 	limit?: number;
+	filteredUsers?: Snowflake[];
 }
 
 export class CorePrecondition extends Precondition {
@@ -20,6 +21,9 @@ export class CorePrecondition extends Precondition {
 
 		// If there is no delay (undefined, null, 0), return ok:
 		if (!context.delay) return this.ok();
+
+		// If the user has provided any filtered users and the message author is in that array, return ok:
+		if (context.filteredUsers?.includes(message.author.id)) return this.ok();
 
 		const ratelimit = this.getManager(command, context).acquire(this.getId(message, context));
 		if (ratelimit.limited) {


### PR DESCRIPTION
This way we can filter out users like the bot owner. It is extremely annoying to run into the cooldown when developing a bot.