### PR TITLE
fix(preconditions): expose name and context values from preconditions array

### DIFF
--- a/src/lib/utils/preconditions/IPreconditionContainer.ts
+++ b/src/lib/utils/preconditions/IPreconditionContainer.ts
@@ -28,20 +28,6 @@ export type AsyncPreconditionContainerReturn = Promise<PreconditionContainerResu
  * @since 1.0.0
  */
 export interface IPreconditionContainer {
-   /**
-	* The context to be used when calling {@link Precondition.run}. This will always be an empty object (`{}`) when the
-	* container was constructed with a string, otherwise it is a direct reference to the value from
-	* {@link PreconditionSingleResolvableDetails.context}.
-	* @since 1.0.0
-	*/
-	public readonly context: Record<PropertyKey, unknown>;
-
-	/**
-	* The name of the precondition to run.
-	* @since 1.0.0
-	*/
-	public readonly name: string;
-
 	/**
 	 * Runs a precondition container.
 	 * @since 1.0.0
@@ -49,4 +35,20 @@ export interface IPreconditionContainer {
 	 * @param command The command the message invoked.
 	 */
 	run(message: Message, command: Command, context?: PreconditionContext): PreconditionContainerReturn;
+}
+
+export interface IPreconditionContainerDetails {
+	/**
+	 * The context to be used when calling {@link Precondition.run}. This will always be an empty object (`{}`) when the
+	 * container was constructed with a string, otherwise it is a direct reference to the value from
+	 * {@link PreconditionSingleResolvableDetails.context}.
+	 * @since 1.0.0
+	 */
+	readonly context?: Record<PropertyKey, unknown>;
+
+	/**
+	 * The name of the precondition to run.
+	 * @since 1.0.0
+	 */
+	readonly name?: string;
 }

--- a/src/lib/utils/preconditions/IPreconditionContainer.ts
+++ b/src/lib/utils/preconditions/IPreconditionContainer.ts
@@ -28,19 +28,19 @@ export type AsyncPreconditionContainerReturn = Promise<PreconditionContainerResu
  * @since 1.0.0
  */
 export interface IPreconditionContainer {
-	/**
-	 * The context to be used when calling {@link Precondition.run}. This will always be an empty object (`{}`) when the
-	 * container was constructed with a string, otherwise it is a direct reference to the value from
-	 * {@link PreconditionSingleResolvableDetails.context}.
-	 * @since 1.0.0
-	 */
-	readonly context: Record<PropertyKey, unknown>;
+   /**
+	* The context to be used when calling {@link Precondition.run}. This will always be an empty object (`{}`) when the
+	* container was constructed with a string, otherwise it is a direct reference to the value from
+	* {@link PreconditionSingleResolvableDetails.context}.
+	* @since 1.0.0
+	*/
+	public readonly context: Record<PropertyKey, unknown>;
 
-	 /**
-	  * The name of the precondition to run.
-	  * @since 1.0.0
-	  */
-	readonly name: string;
+	/**
+	* The name of the precondition to run.
+	* @since 1.0.0
+	*/
+	public readonly name: string;
 
 	/**
 	 * Runs a precondition container.

--- a/src/lib/utils/preconditions/IPreconditionContainer.ts
+++ b/src/lib/utils/preconditions/IPreconditionContainer.ts
@@ -29,6 +29,20 @@ export type AsyncPreconditionContainerReturn = Promise<PreconditionContainerResu
  */
 export interface IPreconditionContainer {
 	/**
+	 * The context to be used when calling {@link Precondition.run}. This will always be an empty object (`{}`) when the
+	 * container was constructed with a string, otherwise it is a direct reference to the value from
+	 * {@link PreconditionSingleResolvableDetails.context}.
+	 * @since 1.0.0
+	 */
+	readonly context: Record<PropertyKey, unknown>;
+
+	 /**
+	  * The name of the precondition to run.
+	  * @since 1.0.0
+	  */
+	readonly name: string;
+
+	/**
 	 * Runs a precondition container.
 	 * @since 1.0.0
 	 * @param message The message that ran this precondition.

--- a/src/lib/utils/preconditions/IPreconditionContainer.ts
+++ b/src/lib/utils/preconditions/IPreconditionContainer.ts
@@ -44,11 +44,11 @@ export interface IPreconditionContainerDetails {
 	 * {@link PreconditionSingleResolvableDetails.context}.
 	 * @since 1.0.0
 	 */
-	readonly context?: Record<PropertyKey, unknown>;
+	readonly context: Record<PropertyKey, unknown>;
 
 	/**
 	 * The name of the precondition to run.
 	 * @since 1.0.0
 	 */
-	readonly name?: string;
+	readonly name: string;
 }

--- a/src/lib/utils/preconditions/PreconditionContainerArray.ts
+++ b/src/lib/utils/preconditions/PreconditionContainerArray.ts
@@ -4,7 +4,7 @@ import type { PreconditionContext, PreconditionKeys, SimplePreconditionKeys } fr
 import type { IPreconditionCondition } from './conditions/IPreconditionCondition';
 import { PreconditionConditionAnd } from './conditions/PreconditionConditionAnd';
 import { PreconditionConditionOr } from './conditions/PreconditionConditionOr';
-import type { IPreconditionContainer, PreconditionContainerReturn } from './IPreconditionContainer';
+import type { IPreconditionContainer, IPreconditionContainerDetails, PreconditionContainerReturn } from './IPreconditionContainer';
 import {
 	PreconditionContainerSingle,
 	PreconditionSingleResolvable,
@@ -116,7 +116,7 @@ export class PreconditionContainerArray implements IPreconditionContainer {
 	 * The {@link IPreconditionContainer}s the array holds.
 	 * @since 1.0.0
 	 */
-	public readonly entries: IPreconditionContainer[];
+	public readonly entries: IPreconditionContainer[] & IPreconditionContainerDetails[];
 
 	/**
 	 * The {@link PreconditionRunCondition} that defines how entries must be handled.

--- a/src/lib/utils/preconditions/PreconditionContainerSingle.ts
+++ b/src/lib/utils/preconditions/PreconditionContainerSingle.ts
@@ -47,6 +47,20 @@ export type PreconditionSingleResolvable = SimplePreconditionKeys | SimplePrecon
  * @since 1.0.0
  */
 export class PreconditionContainerSingle implements IPreconditionContainer {
+	/**
+	 * The context to be used when calling {@link Precondition.run}. This will always be an empty object (`{}`) when the
+	 * container was constructed with a string, otherwise it is a direct reference to the value from
+	 * {@link PreconditionSingleResolvableDetails.context}.
+	 * @since 1.0.0
+	 */
+	public readonly context: Record<PropertyKey, unknown>;
+
+	/**
+	 * The name of the precondition to run.
+	 * @since 1.0.0
+	 */
+	public readonly name: string;
+
 	public constructor(data: PreconditionSingleResolvable) {
 		if (typeof data === 'string') {
 			this.context = {};

--- a/src/lib/utils/preconditions/PreconditionContainerSingle.ts
+++ b/src/lib/utils/preconditions/PreconditionContainerSingle.ts
@@ -47,20 +47,6 @@ export type PreconditionSingleResolvable = SimplePreconditionKeys | SimplePrecon
  * @since 1.0.0
  */
 export class PreconditionContainerSingle implements IPreconditionContainer {
-	/**
-	 * The context to be used when calling {@link Precondition.run}. This will always be an empty object (`{}`) when the
-	 * container was constructed with a string, otherwise it is a direct reference to the value from
-	 * {@link PreconditionSingleResolvableDetails.context}.
-	 * @since 1.0.0
-	 */
-	public readonly context: Record<PropertyKey, unknown>;
-
-	/**
-	 * The name of the precondition to run.
-	 * @since 1.0.0
-	 */
-	public readonly name: string;
-
 	public constructor(data: PreconditionSingleResolvable) {
 		if (typeof data === 'string') {
 			this.context = {};


### PR DESCRIPTION
I have noticed that only the run method is exposed when mapping the preconditions of the current piece (command), and not the name and context values, which can be important when doing certain tasks and exposing them will lead to more possibilities to use the array of preconditions of the pieces (commands).