### PR TITLE
feat: add managed role mention prefix support

### DIFF
--- a/src/listeners/command-handler/CoreMessageParser.ts
+++ b/src/listeners/command-handler/CoreMessageParser.ts
@@ -16,24 +16,16 @@ export class CoreListener extends Listener<typeof Events.PreMessageParsed> {
 		if (!canRun) return;
 
 		let prefix = null;
-		const userMentionPrefix = this.getUserMentionPrefix(message.content);
-		const managedRoleMentionPrefix = this.getManagedRoleMentionPrefix(message);
+		const mentionPrefix = this.getUserMentionPrefix(message.content) ?? this.getManagedRoleMentionPrefix(message);
 		const { client } = this.container;
 		const { regexPrefix } = client.options;
-		if (userMentionPrefix) {
-			if (message.content.length === userMentionPrefix.length) {
+		if (mentionPrefix) {
+			if (message.content.length === mentionPrefix.length) {
 				client.emit(Events.MentionPrefixOnly, message);
 				return;
 			}
 
-			prefix = userMentionPrefix;
-		} else if (managedRoleMentionPrefix) {
-			if (message.content.length === managedRoleMentionPrefix.length) {
-				client.emit(Events.MentionPrefixOnly, message);
-				return;
-			}
-
-			prefix = managedRoleMentionPrefix;
+			prefix = mentionPrefix;
 		} else if (regexPrefix?.test(message.content)) {
 			prefix = regexPrefix;
 		} else {

--- a/src/listeners/command-handler/CoreMessageParser.ts
+++ b/src/listeners/command-handler/CoreMessageParser.ts
@@ -16,7 +16,7 @@ export class CoreListener extends Listener<typeof Events.PreMessageParsed> {
 		if (!canRun) return;
 
 		let prefix = null;
-		const mentionPrefix = this.getUserMentionPrefix(message.content) ?? this.getManagedRoleMentionPrefix(message);
+		const mentionPrefix = this.getMentionPrefix(message);
 		const { client } = this.container;
 		const { regexPrefix } = client.options;
 		if (mentionPrefix) {
@@ -48,56 +48,24 @@ export class CoreListener extends Listener<typeof Events.PreMessageParsed> {
 		return channel.permissionsFor(me).has(this.requiredPermissions, false);
 	}
 
-	private getUserMentionPrefix(content: string): string | null {
-		const { id } = this.container.client;
+	private getMentionPrefix(message: Message): string | null {
+		// If the content is shorter than 20 characters, or does not start with `<@` then skip early:
+		if (message.content.length < 20 || !message.content.startsWith('<@')) return null;
 
-		// If no client ID was specified then skip early
+		// Calculate the offset and the ID that is being provided
+		const [offset, id] =
+			message.content[2] === '&'
+				? [3, message.guild?.roles.botRoleFor(message.guild.me!)?.id]
+				: [message.content[2] === '!' ? 3 : 2, this.container.client.id];
+
 		if (!id) return null;
 
-		// If the content is shorter than `<@{n}>` or doesn't start with `<@` then skip early:
-		if (content.length < 20 || !content.startsWith('<@')) return null;
-
-		// Retrieve whether the mention is a nickname mention (`<@!{n}>`) or not (`<@{n}>`).
-		const nickname = content[2] === '!';
-		const idOffset = (nickname ? 3 : 2) as number;
-		const idLength = id.length;
-
-		// If the mention doesn't end with `>` then skip early:
-		if (content[idOffset + idLength] !== '>') return null;
-
-		// Check whether or not the ID is the same as the client ID:
-		const mentionId = content.substr(idOffset, idLength);
-		if (mentionId === id) return content.substr(0, idOffset + idLength + 1);
-
-		return null;
-	}
-
-	private getManagedRoleMentionPrefix(message: Message): string | null {
-		// If the message does not originate in a guild then skip early
-		if (!message.guild) return null;
-
-		// If there is no user on the client then skip early
-		if (!this.container.client.user) return null;
-
-		// If the content is shorter than `<@&{n}>` or doesn't start with `<@&` then skip early:
-		if (message.content.length < 21 || !message.content.startsWith('<@&')) return null;
-
-		// The ID in the message content is offset by 3 characters (`<@&`)
-		const idOffset = 3;
-
-		// Get the length managed role
-		const managedRole = message.guild.roles.botRoleFor(this.container.client.user);
-		const managedRoleIdLength = managedRole?.id.length;
-
-		// If there is no managed role or the length of the role ID is falsy then skip early
-		if (!managedRole || !managedRoleIdLength) return null;
-
 		// If the mention doesn't end with `>`, skip early:
-		if (message.content[idOffset + managedRoleIdLength] !== '>') return null;
+		if (message.content[offset + id.length] !== '>') return null;
 
 		// Check whether or not the ID is the same as the managed role ID:
-		const mentionId = message.content.substr(idOffset, managedRoleIdLength);
-		if (mentionId === managedRole.id) return message.content.substr(0, idOffset + managedRoleIdLength + 1);
+		const mentionId = message.content.substr(offset, id.length);
+		if (mentionId === id) return message.content.substr(0, offset + id.length + 1);
 
 		return null;
 	}


### PR DESCRIPTION
After this PR it will also be possible to trigger commands by using `@ManagedRole command`. This is useful because Discord adds a Managed Role with the same name as the Client when adding a bot with permissions, and especially in smaller servers it can happen that you accidentally mention the role instead of the bot.