### PR TITLE
fix: make from/fromAsync return `unknown` to match TypeScript

### DIFF
--- a/src/errorListeners/CoreCommandError.ts
+++ b/src/errorListeners/CoreCommandError.ts
@@ -7,7 +7,7 @@ export class CoreEvent extends Listener<typeof Events.CommandError> {
 		super(context, { event: Events.CommandError });
 	}
 
-	public run(error: Error, context: CommandErrorPayload) {
+	public run(error: unknown, context: CommandErrorPayload) {
 		const { name, location } = context.piece;
 		this.container.logger.error(`Encountered error on command "${name}" at path "${location.full}"`, error);
 	}

--- a/src/lib/structures/Listener.ts
+++ b/src/lib/structures/Listener.ts
@@ -121,7 +121,7 @@ export abstract class Listener<E extends keyof ClientEvents | symbol = ''> exten
 	private async _run(...args: unknown[]) {
 		const result = await fromAsync(() => this.run(...args));
 		if (isErr(result)) {
-			this.container.client.emit(Events.ListenerError, result.error as Error, { piece: this });
+			this.container.client.emit(Events.ListenerError, result.error, { piece: this });
 		}
 	}
 

--- a/src/lib/types/Events.ts
+++ b/src/lib/types/Events.ts
@@ -137,7 +137,7 @@ declare module 'discord.js' {
 		[Events.PieceUnload]: [store: Store<Piece>, piece: Piece];
 		[Events.PiecePostLoad]: [store: Store<Piece>, piece: Piece];
 		[Events.MentionPrefixOnly]: [message: Message];
-		[Events.ListenerError]: [error: Error, payload: ListenerErrorPayload];
+		[Events.ListenerError]: [error: unknown, payload: ListenerErrorPayload];
 		[Events.PreMessageParsed]: [message: Message];
 		[Events.PrefixedMessage]: [message: Message, prefix: string | RegExp];
 		[Events.UnknownCommandName]: [payload: UnknownCommandNamePayload];
@@ -147,9 +147,9 @@ declare module 'discord.js' {
 		[Events.CommandAccepted]: [payload: CommandAcceptedPayload];
 		[Events.CommandRun]: [message: Message, command: Command, payload: CommandRunPayload];
 		[Events.CommandSuccess]: [payload: CommandSuccessPayload];
-		[Events.CommandError]: [error: Error, payload: CommandErrorPayload];
+		[Events.CommandError]: [error: unknown, payload: CommandErrorPayload];
 		[Events.CommandFinish]: [message: Message, command: Command, payload: CommandFinishPayload];
-		[Events.CommandTypingError]: [error: Error, payload: CommandTypingErrorPayload];
+		[Events.CommandTypingError]: [error: unknown, payload: CommandTypingErrorPayload];
 		[Events.PluginLoaded]: [hook: PluginHook, name: string | undefined];
 		[Events.NonPrefixedMessage]: [message: Message];
 		// #endregion Sapphire load cycle events

--- a/src/listeners/command-handler/CoreCommandAccepted.ts
+++ b/src/listeners/command-handler/CoreCommandAccepted.ts
@@ -18,7 +18,7 @@ export class CoreListener extends Listener<typeof Events.CommandAccepted> {
 		});
 
 		if (isErr(result)) {
-			message.client.emit(Events.CommandError, result.error as Error, { ...payload, args, piece: command });
+			message.client.emit(Events.CommandError, result.error, { ...payload, args, piece: command });
 		}
 
 		message.client.emit(Events.CommandFinish, message, command, { ...payload, args });

--- a/src/listeners/command-handler/CoreCommandTyping.ts
+++ b/src/listeners/command-handler/CoreCommandTyping.ts
@@ -16,7 +16,7 @@ export class CoreListener extends Listener<typeof Events.CommandRun> {
 		try {
 			await message.channel.sendTyping();
 		} catch (error) {
-			message.client.emit(Events.CommandTypingError, error as Error, { ...payload, command, message });
+			message.client.emit(Events.CommandTypingError, error, { ...payload, command, message });
 		}
 	}
 }


### PR DESCRIPTION
BREAKING CHANGE: For TypeScript users only, if you were previously using `from` or `fromAsync` and you expected the error result to be of type `Error`, it will now be `unknown`. You can reset this back to `Error` by providing it as the second generic type argument.
