### PR TITLE
fix(SapphireClient): include `Ready` generic type from parent `Client`

### DIFF
--- a/src/lib/SapphireClient.ts
+++ b/src/lib/SapphireClient.ts
@@ -167,7 +167,7 @@ export interface SapphireClientOptions {
  * });
  * ```
  */
-export class SapphireClient extends Client {
+export class SapphireClient<Ready extends boolean = boolean> extends Client<Ready> {
 	/**
 	 * The client's ID, used for the user prefix.
 	 * @since 1.0.0


### PR DESCRIPTION
This generic was created [in this PR](https://github.com/discordjs/discord.js/commit/4206e35b2316431c1a009664636dcda85d39fff8) and it would be helpful if we could use it through the `SapphireClient` as well