### PR TITLE
feat(preconditions): export all core preconditions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,11 @@ export * as CorePreconditions from './preconditions';
 export type { CooldownContext } from './preconditions/Cooldown';
 
 /**
+ * @deprecated. Please use `CorePreconditions.ClientPermissions`. `ClientPermissionsCorePrecondition` will be removed in v3.0.0
+ */
+export { CorePrecondition as ClientPermissionsCorePrecondition } from './preconditions/ClientPermissions';
+
+/**
  * The [@sapphire/framework](https://github.com/sapphiredev/framework) version that you are currently using.
  * An example use of this is showing it of in a bot information command.
  *

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,8 +47,8 @@ export * from './lib/utils/preconditions/containers/UserPermissionsPrecondition'
 export * from './lib/utils/preconditions/IPreconditionContainer';
 export * from './lib/utils/preconditions/PreconditionContainerArray';
 export * from './lib/utils/preconditions/PreconditionContainerSingle';
+export * as CorePreconditions from './preconditions';
 export type { CooldownContext } from './preconditions/Cooldown';
-export { CorePrecondition as ClientPermissionsCorePrecondition } from './preconditions/ClientPermissions';
 
 /**
  * The [@sapphire/framework](https://github.com/sapphiredev/framework) version that you are currently using.

--- a/src/preconditions/index.ts
+++ b/src/preconditions/index.ts
@@ -1,0 +1,13 @@
+export { CorePrecondition as ClientPermissions } from './ClientPermissions';
+export { CorePrecondition as Cooldown } from './Cooldown';
+export { CorePrecondition as DMOnly } from './DMOnly';
+export { CorePrecondition as Enabled } from './Enabled';
+export { CorePrecondition as GuildNewsOnly } from './GuildNewsOnly';
+export { CorePrecondition as GuildNewsThreadOnly } from './GuildNewsThreadOnly';
+export { CorePrecondition as GuildOnly } from './GuildOnly';
+export { CorePrecondition as GuildPrivateThreadOnly } from './GuildPrivateThreadOnly';
+export { CorePrecondition as GuildPublicThreadOnly } from './GuildPublicThreadOnly';
+export { CorePrecondition as GuildTextOnly } from './GuildTextOnly';
+export { CorePrecondition as GuildThreadOnly } from './GuildThreadOnly';
+export { CorePrecondition as NSFW } from './NSFW';
+export { CorePrecondition as UserPermissions } from './UserPermissions';


### PR DESCRIPTION
This PR will allow extensions of core preconditions via `CorePreconditions.*`. See also #320.
The code changes themselves are self-explanatory. One change that will affect users is that **`ClientPermissionsCorePrecondition` will now be accessible via `CorePreconditions.ClientPermissions`**.
