### PR TITLE
refactor: edit cooldown message

### DIFF
--- a/src/preconditions/Cooldown.ts
+++ b/src/preconditions/Cooldown.ts
@@ -30,7 +30,7 @@ export class CorePrecondition extends Precondition {
 			const remaining = ratelimit.remainingTime;
 			return this.error({
 				identifier: Identifiers.PreconditionCooldown,
-				message: `You have just used this command. Try again in ${Math.ceil(remaining / 1000)} second${remaining > 1000 ? 's' : ''}.`,
+				message: `There is a cooldown in effect for this command. It can be used again in ${Math.ceil(remaining / 1000)} second${remaining > 1000 ? 's' : ''}.`,
 				context: { remaining }
 			});
 		}

--- a/src/preconditions/Cooldown.ts
+++ b/src/preconditions/Cooldown.ts
@@ -30,7 +30,9 @@ export class CorePrecondition extends Precondition {
 			const remaining = ratelimit.remainingTime;
 			return this.error({
 				identifier: Identifiers.PreconditionCooldown,
-				message: `There is a cooldown in effect for this command. It can be used again in ${Math.ceil(remaining / 1000)} second${remaining > 1000 ? 's' : ''}.`,
+				message: `There is a cooldown in effect for this command. It can be used again in ${Math.ceil(remaining / 1000)} second${
+					remaining > 1000 ? 's' : ''
+				}.`,
 				context: { remaining }
 			});
 		}


### PR DESCRIPTION
This will be more accurate when the scope is set to anything other than `USER` because they might've not just used the command. Furthermore, the "just" part is removed, since the cooldown could be 1 hour for all we know, making this a purely factual message 🙂

While you're here, I think it might be worth talking about using `DurationFormatter` from /time-utilities so that things aren't measured in only seconds. However, the drawback would be adding a dependency for a very very small use case in a project that prides itself (or should pride itself) on not having many.