### PR TITLE
style: fix jsdoc for `runIn` option

### DIFF
--- a/src/lib/structures/Command.ts
+++ b/src/lib/structures/Command.ts
@@ -363,7 +363,7 @@ export const enum CommandOptionsRunTypeEnum {
 	GuildPublicThread = 'GUILD_PUBLIC_THREAD',
 	GuildPrivateThread = 'GUILD_PRIVATE_THREAD',
 	GuildAny = 'GUILD_ANY'
-} book
+}
 
 /**
  * The available command pre-conditions.

--- a/src/lib/structures/Command.ts
+++ b/src/lib/structures/Command.ts
@@ -363,7 +363,7 @@ export const enum CommandOptionsRunTypeEnum {
 	GuildPublicThread = 'GUILD_PUBLIC_THREAD',
 	GuildPrivateThread = 'GUILD_PRIVATE_THREAD',
 	GuildAny = 'GUILD_ANY'
-}
+} book
 
 /**
  * The available command pre-conditions.
@@ -496,7 +496,7 @@ export interface CommandOptions extends AliasPiece.Options, FlagStrategyOptions 
 	requiredUserPermissions?: PermissionResolvable;
 
 	/**
-	 * The channels the command should run in. If set to `null`, no precondition entry will be added. Some optimizations are applied when given an array to reduce the amount of preconditions run (e.g. `'text'` and `'news'` becomes `'guild'`, and if both `'dm'` and `'guild'` are defined, then no precondition entry is added as it runs in all channels).
+	 * The channels the command should run in. If set to `null`, no precondition entry will be added. Some optimizations are applied when given an array to reduce the amount of preconditions run (e.g. `'GUILD_TEXT'` and `'GUILD_NEWS'` becomes `'GUILD_ANY'`, and if both `'DM'` and `'GUILD_ANY'` are defined, then no precondition entry is added as it runs in all channels).
 	 * @since 2.0.0
 	 * @default null
 	 */


### PR DESCRIPTION
This was the most logical replacement of names I could think of, but the code itself confused me, so you'll have to tell me if it's actually accurate.