### PR TITLE
fix: make `BooleanArgument`/`resolveBoolean`'s contexts immutable

### DIFF
--- a/src/arguments/CoreBoolean.ts
+++ b/src/arguments/CoreBoolean.ts
@@ -7,7 +7,7 @@ export class CoreArgument extends Argument<boolean> {
 		super(context, { name: 'boolean' });
 	}
 
-	public run(parameter: string, context: { truths?: string[]; falses?: string[] } & Argument.Context): Argument.Result<boolean> {
+	public run(parameter: string, context: { readonly truths?: string[]; falses?: readonly string[] } & Argument.Context): Argument.Result<boolean> {
 		const resolved = resolveBoolean(parameter, { truths: context.truths, falses: context.falses });
 		if (resolved.success) return this.ok(resolved.value);
 		return this.error({

--- a/src/lib/resolvers/boolean.ts
+++ b/src/lib/resolvers/boolean.ts
@@ -1,12 +1,12 @@
 import { Identifiers } from '../errors/Identifiers';
 import { err, ok, Result } from '../parsers/Result';
 
-const baseTruths = ['1', 'true', '+', 't', 'yes', 'y'];
-const baseFalses = ['0', 'false', '-', 'f', 'no', 'n'];
+const baseTruths = ['1', 'true', '+', 't', 'yes', 'y'] as const;
+const baseFalses = ['0', 'false', '-', 'f', 'no', 'n'] as const;
 
 export function resolveBoolean(
 	parameter: string,
-	customs?: { truths?: string[]; falses?: string[] }
+	customs?: { truths?: readonly string[]; falses?: readonly string[] }
 ): Result<boolean, Identifiers.ArgumentBooleanError> {
 	const boolean = parameter.toLowerCase();
 	if ([...baseTruths, ...(customs?.truths ?? [])].includes(boolean)) return ok(true);


### PR DESCRIPTION
Made truths/falses arrays readonly