### PR TITLE
feat: add duration to `*Error` and `*Finished` `Message`, `ChatInput` and `ContextMenu` Command events

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 		"@sapphire/discord.js-utilities": "^4.1.5",
 		"@sapphire/pieces": "^3.2.0",
 		"@sapphire/ratelimits": "^2.1.10",
+		"@sapphire/stopwatch": "^1.2.0",
 		"@sapphire/utilities": "^3.1.0",
 		"lexure": "^0.17.0",
 		"tslib": "^2.3.1"

--- a/src/lib/types/Events.ts
+++ b/src/lib/types/Events.ts
@@ -198,6 +198,7 @@ export interface MessageCommandDeniedPayload extends IMessageCommandPayload {
 export interface MessageCommandAcceptedPayload extends IMessageCommandPayload {
 	parameters: string;
 	context: MessageCommand.RunContext;
+	duration?: number;
 }
 
 export interface MessageCommandRunPayload extends MessageCommandAcceptedPayload {

--- a/src/lib/types/Events.ts
+++ b/src/lib/types/Events.ts
@@ -198,16 +198,19 @@ export interface MessageCommandDeniedPayload extends IMessageCommandPayload {
 export interface MessageCommandAcceptedPayload extends IMessageCommandPayload {
 	parameters: string;
 	context: MessageCommand.RunContext;
-	duration?: number;
 }
 
 export interface MessageCommandRunPayload extends MessageCommandAcceptedPayload {
 	args: unknown;
 }
 
-export interface MessageCommandFinishPayload extends MessageCommandRunPayload {}
+export interface MessageCommandFinishPayload extends MessageCommandRunPayload {
+	duration: number;
+}
 
-export interface MessageCommandErrorPayload extends MessageCommandRunPayload {}
+export interface MessageCommandErrorPayload extends MessageCommandRunPayload {
+	duration: number;
+}
 
 export interface MessageCommandSuccessPayload extends MessageCommandRunPayload {
 	result: unknown;
@@ -229,7 +232,6 @@ export interface CommandDoesNotHaveChatInputCommandHandlerPayload {
 export interface IChatInputCommandPayload {
 	interaction: CommandInteraction;
 	command: ChatInputCommand;
-	duration?: number;
 }
 
 export interface PreChatInputCommandRunPayload extends IChatInputCommandPayload {
@@ -244,11 +246,17 @@ export interface ChatInputCommandAcceptedPayload extends PreChatInputCommandRunP
 
 export interface ChatInputCommandRunPayload extends ChatInputCommandAcceptedPayload {}
 
+export interface ChatInputCommandFinishPayload extends ChatInputCommandAcceptedPayload {
+	duration: number;
+}
+
 export interface ChatInputCommandSuccessPayload extends ChatInputCommandRunPayload {
 	result: unknown;
 }
 
-export interface ChatInputCommandErrorPayload extends IChatInputCommandPayload {}
+export interface ChatInputCommandErrorPayload extends IChatInputCommandPayload {
+	duration: number;
+}
 
 export interface UnknownContextMenuCommandPayload {
 	interaction: ContextMenuInteraction;
@@ -264,7 +272,6 @@ export interface CommandDoesNotHaveContextMenuCommandHandlerPayload {
 export interface IContextMenuCommandPayload {
 	interaction: ContextMenuInteraction;
 	command: ContextMenuCommand;
-	duration?: number;
 }
 
 export interface PreContextMenuCommandRunPayload extends IContextMenuCommandPayload {
@@ -279,11 +286,17 @@ export interface ContextMenuCommandAcceptedPayload extends PreContextMenuCommand
 
 export interface ContextMenuCommandRunPayload extends ContextMenuCommandAcceptedPayload {}
 
+export interface ContextMenuCommandFinishPayload extends ContextMenuCommandAcceptedPayload {
+	duration: number;
+}
+
 export interface ContextMenuCommandSuccessPayload extends ContextMenuCommandRunPayload {
 	result: unknown;
 }
 
-export interface ContextMenuCommandErrorPayload extends IContextMenuCommandPayload {}
+export interface ContextMenuCommandErrorPayload extends IContextMenuCommandPayload {
+	duration: number;
+}
 
 export interface IInteractionHandlerPayload {
 	interaction: Interaction;
@@ -350,7 +363,7 @@ declare module 'discord.js' {
 		[Events.ChatInputCommandRun]: [interaction: CommandInteraction, command: ChatInputCommand, payload: ChatInputCommandRunPayload];
 		[Events.ChatInputCommandSuccess]: [payload: ChatInputCommandSuccessPayload];
 		[Events.ChatInputCommandError]: [error: unknown, payload: ChatInputCommandErrorPayload];
-		[Events.ChatInputCommandFinish]: [interaction: CommandInteraction, command: ChatInputCommand, payload: ChatInputCommandRunPayload];
+		[Events.ChatInputCommandFinish]: [interaction: CommandInteraction, command: ChatInputCommand, payload: ChatInputCommandFinishPayload];
 
 		// Context menu command chain
 		[Events.PossibleContextMenuCommand]: [interaction: ContextMenuInteraction];
@@ -364,7 +377,11 @@ declare module 'discord.js' {
 		[Events.ContextMenuCommandRun]: [interaction: ContextMenuInteraction, command: ContextMenuCommand, payload: ContextMenuCommandRunPayload];
 		[Events.ContextMenuCommandSuccess]: [payload: ContextMenuCommandSuccessPayload];
 		[Events.ContextMenuCommandError]: [error: unknown, payload: ContextMenuCommandErrorPayload];
-		[Events.ContextMenuCommandFinish]: [interaction: ContextMenuInteraction, command: ContextMenuCommand, payload: ContextMenuCommandRunPayload];
+		[Events.ContextMenuCommandFinish]: [
+			interaction: ContextMenuInteraction,
+			command: ContextMenuCommand,
+			payload: ContextMenuCommandFinishPayload
+		];
 
 		// #endregion Sapphire load cycle events
 

--- a/src/lib/types/Events.ts
+++ b/src/lib/types/Events.ts
@@ -228,6 +228,7 @@ export interface CommandDoesNotHaveChatInputCommandHandlerPayload {
 export interface IChatInputCommandPayload {
 	interaction: CommandInteraction;
 	command: ChatInputCommand;
+	duration?: number;
 }
 
 export interface PreChatInputCommandRunPayload extends IChatInputCommandPayload {
@@ -262,6 +263,7 @@ export interface CommandDoesNotHaveContextMenuCommandHandlerPayload {
 export interface IContextMenuCommandPayload {
 	interaction: ContextMenuInteraction;
 	command: ContextMenuCommand;
+	duration?: number;
 }
 
 export interface PreContextMenuCommandRunPayload extends IContextMenuCommandPayload {

--- a/src/listeners/application-commands/chat-input/CoreChatInputCommandAccepted.ts
+++ b/src/listeners/application-commands/chat-input/CoreChatInputCommandAccepted.ts
@@ -1,4 +1,5 @@
 import type { PieceContext } from '@sapphire/pieces';
+import { Stopwatch } from '@sapphire/stopwatch';
 import { fromAsync, isErr } from '../../../lib/parsers/Result';
 import { Listener } from '../../../lib/structures/Listener';
 import { ChatInputCommandAcceptedPayload, Events } from '../../../lib/types/Events';
@@ -11,16 +12,18 @@ export class CoreListener extends Listener<typeof Events.ChatInputCommandAccepte
 	public async run(payload: ChatInputCommandAcceptedPayload) {
 		const { command, context, interaction } = payload;
 
+		const stopwatch = new Stopwatch();
 		const result = await fromAsync(async () => {
 			this.container.client.emit(Events.ChatInputCommandRun, interaction, command, { ...payload });
 			const result = await command.chatInputRun(interaction, context);
 			this.container.client.emit(Events.ChatInputCommandSuccess, { ...payload, result });
 		});
 
+		const { duration } = stopwatch.stop();
 		if (isErr(result)) {
-			this.container.client.emit(Events.ChatInputCommandError, result.error, { ...payload });
+			this.container.client.emit(Events.ChatInputCommandError, result.error, { ...payload, duration });
 		}
 
-		this.container.client.emit(Events.ChatInputCommandFinish, interaction, command, { ...payload });
+		this.container.client.emit(Events.ChatInputCommandFinish, interaction, command, { ...payload, duration });
 	}
 }

--- a/src/listeners/application-commands/context-menu/CoreContextMenuCommandAccepted.ts
+++ b/src/listeners/application-commands/context-menu/CoreContextMenuCommandAccepted.ts
@@ -1,4 +1,5 @@
 import type { PieceContext } from '@sapphire/pieces';
+import { Stopwatch } from '@sapphire/stopwatch';
 import { fromAsync, isErr } from '../../../lib/parsers/Result';
 import { Listener } from '../../../lib/structures/Listener';
 import { ContextMenuCommandAcceptedPayload, Events } from '../../../lib/types/Events';
@@ -11,16 +12,18 @@ export class CoreListener extends Listener<typeof Events.ContextMenuCommandAccep
 	public async run(payload: ContextMenuCommandAcceptedPayload) {
 		const { command, context, interaction } = payload;
 
+		const stopwatch = new Stopwatch();
 		const result = await fromAsync(async () => {
 			this.container.client.emit(Events.ContextMenuCommandRun, interaction, command, { ...payload });
 			const result = await command.contextMenuRun(interaction, context);
 			this.container.client.emit(Events.ContextMenuCommandSuccess, { ...payload, result });
 		});
 
+		const { duration } = stopwatch.stop();
 		if (isErr(result)) {
-			this.container.client.emit(Events.ContextMenuCommandError, result.error, { ...payload });
+			this.container.client.emit(Events.ContextMenuCommandError, result.error, { ...payload, duration });
 		}
 
-		this.container.client.emit(Events.ContextMenuCommandFinish, interaction, command, { ...payload });
+		this.container.client.emit(Events.ContextMenuCommandFinish, interaction, command, { ...payload, duration });
 	}
 }

--- a/src/optional-listeners/message-command-listeners/CoreMessageCommandAccepted.ts
+++ b/src/optional-listeners/message-command-listeners/CoreMessageCommandAccepted.ts
@@ -2,6 +2,7 @@ import type { PieceContext } from '@sapphire/pieces';
 import { Listener } from '../../lib/structures/Listener';
 import { MessageCommandAcceptedPayload, Events } from '../../lib/types/Events';
 import { isErr, fromAsync } from '../../lib/parsers/Result';
+import { Stopwatch } from '@sapphire/stopwatch';
 
 export class CoreListener extends Listener<typeof Events.MessageCommandAccepted> {
 	public constructor(context: PieceContext) {
@@ -11,16 +12,19 @@ export class CoreListener extends Listener<typeof Events.MessageCommandAccepted>
 	public async run(payload: MessageCommandAcceptedPayload) {
 		const { message, command, parameters, context } = payload;
 		const args = await command.messagePreParse(message, parameters, context);
+
+		const stopwatch = new Stopwatch();
 		const result = await fromAsync(async () => {
 			message.client.emit(Events.MessageCommandRun, message, command, { ...payload, args });
 			const result = await command.messageRun(message, args, context);
 			message.client.emit(Events.MessageCommandSuccess, { ...payload, args, result });
 		});
 
+		const { duration } = stopwatch.stop();
 		if (isErr(result)) {
-			message.client.emit(Events.MessageCommandError, result.error, { ...payload, args });
+			message.client.emit(Events.MessageCommandError, result.error, { ...payload, args, duration });
 		}
 
-		message.client.emit(Events.MessageCommandFinish, message, command, { ...payload, args });
+		message.client.emit(Events.MessageCommandFinish, message, command, { ...payload, args, duration });
 	}
 }

--- a/src/optional-listeners/message-command-listeners/CoreMessageCommandAccepted.ts
+++ b/src/optional-listeners/message-command-listeners/CoreMessageCommandAccepted.ts
@@ -1,8 +1,8 @@
 import type { PieceContext } from '@sapphire/pieces';
-import { Listener } from '../../lib/structures/Listener';
-import { MessageCommandAcceptedPayload, Events } from '../../lib/types/Events';
-import { isErr, fromAsync } from '../../lib/parsers/Result';
 import { Stopwatch } from '@sapphire/stopwatch';
+import { fromAsync, isErr } from '../../lib/parsers/Result';
+import { Listener } from '../../lib/structures/Listener';
+import { Events, MessageCommandAcceptedPayload } from '../../lib/types/Events';
 
 export class CoreListener extends Listener<typeof Events.MessageCommandAccepted> {
 	public constructor(context: PieceContext) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1041,6 +1041,7 @@ __metadata:
     "@sapphire/pieces": ^3.2.0
     "@sapphire/prettier-config": ^1.2.7
     "@sapphire/ratelimits": ^2.1.10
+    "@sapphire/stopwatch": ^1.2.0
     "@sapphire/ts-config": ^3.1.6
     "@sapphire/utilities": ^3.1.0
     "@types/jest": ^27.4.0
@@ -1100,6 +1101,15 @@ __metadata:
   dependencies:
     "@sapphire/time-utilities": ^1.5.0
   checksum: 6f4bc917ba549ab11ef63f4aea3a2356962d556352257d0fdef7a5e2a8bda4ca00ce80752dee4660f716bfd49de3e2e527c03783dc74b13d0f155ef1356a976b
+  languageName: node
+  linkType: hard
+
+"@sapphire/stopwatch@npm:^1.2.0":
+  version: 1.2.4
+  resolution: "@sapphire/stopwatch@npm:1.2.4"
+  dependencies:
+    tslib: ^2.3.1
+  checksum: 0841a5a728a06c556e85470d1d5bb57646829b266ef8ab3c46ac998665edad1dba4eca0aaf689716f91ed4abca58882a93cde2ca354ca51f9c05b568d9be1308
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
New PR after mistakenly autoclosing #356 

---

_Maintainer edit:_

BREAKING CHANGE: The payload for `Events.ChatInputCommandFinish` has been changed from `ChatInputCommandRunPayload` to `ChatInputCommandFinishPayload`
BREAKING CHANGE: The payload for `Events.ContextMenuCommandFinish` has been changed from `ContextMenuCommandRunPayload` to `ContextMenuCommandFinishPayload`