### PR TITLE
A fix, a feat and a refactor all for Vladdy

### DIFF
--- a/src/lib/structures/InteractionHandler.ts
+++ b/src/lib/structures/InteractionHandler.ts
@@ -3,7 +3,7 @@ import type { Awaitable } from '@sapphire/utilities';
 import type { Interaction } from 'discord.js';
 import { some, Maybe, none, None, UnwrapMaybeValue } from '../parsers/Maybe';
 
-export abstract class InteractionHandler extends Piece {
+export abstract class InteractionHandler<O extends InteractionHandler.Options = InteractionHandler.Options> extends Piece<O> {
 	/**
 	 * The type for this handler
 	 * @since 3.0.0

--- a/src/lib/structures/InteractionHandler.ts
+++ b/src/lib/structures/InteractionHandler.ts
@@ -91,10 +91,12 @@ export interface InteractionHandlerJSON extends PieceJSON {
 	interactionHandlerType: InteractionHandlerTypes;
 }
 
+export type InteractionHandlerParseResult<Instance extends InteractionHandler> = UnwrapMaybeValue<Awaited<ReturnType<Instance['parse']>>>;
+
 export namespace InteractionHandler {
 	export type Options = InteractionHandlerOptions;
 	export type JSON = InteractionHandlerJSON;
-	export type ParseResult<Instance extends InteractionHandler> = UnwrapMaybeValue<Awaited<ReturnType<Instance['parse']>>>;
+	export type ParseResult<Instance extends InteractionHandler> = InteractionHandlerParseResult<Instance>;
 }
 
 export const enum InteractionHandlerTypes {

--- a/src/lib/structures/InteractionHandler.ts
+++ b/src/lib/structures/InteractionHandler.ts
@@ -84,6 +84,9 @@ export abstract class InteractionHandler<O extends InteractionHandler.Options = 
 }
 
 export interface InteractionHandlerOptions extends PieceOptions {
+	/**
+	 * The type of interaction this handler is for. Must be one of {@link InteractionHandlerTypes}.
+	 */
 	readonly interactionHandlerType: InteractionHandlerTypes;
 }
 

--- a/src/lib/structures/Precondition.ts
+++ b/src/lib/structures/Precondition.ts
@@ -10,7 +10,7 @@ import type { ChatInputCommand, ContextMenuCommand, MessageCommand } from './Com
 export type PreconditionResult = Awaitable<Result<unknown, UserError>>;
 export type AsyncPreconditionResult = Promise<Result<unknown, UserError>>;
 
-export class Precondition<O extends PreconditionOptions = PreconditionOptions> extends Piece<O> {
+export class Precondition<O extends Precondition.Options = Precondition.Options> extends Piece<O> {
 	public readonly position: number | null;
 
 	public constructor(context: Piece.Context, options: Precondition.Options = {}) {


### PR DESCRIPTION
- fix: specify generic for InteractionHandler options
- feat: extract `InteractionHandlerParseResult` from `InteractionHandler` namespace
  Namespaced types should be an alternative short-circuit way of accessing those types,
not the only way.
- refactor: change generic in Precondition to use namespaced type
- docs: add tsdoc to `InteractionHandlerOptions.interactionHandlerType`