### PR TITLE
feat(command): add Interaction and Registry namespace members

### DIFF
--- a/src/lib/structures/Command.ts
+++ b/src/lib/structures/Command.ts
@@ -805,7 +805,9 @@ export namespace Command {
 	export type JSON = CommandJSON;
 	export type Context = AliasPiece.Context;
 	export type RunInTypes = CommandOptionsRunType;
-	export type Interaction = CommandInteraction;
+	export type ChatInputInteraction = CommandInteraction;
+	export type ContextMenuInteraction = ContextMenuInteraction;
+	export type AutocompleteInteraction = AutocompleteInteraction;
 	export type Registry = ApplicationCommandRegistry;
 }
 

--- a/src/lib/structures/Command.ts
+++ b/src/lib/structures/Command.ts
@@ -805,6 +805,8 @@ export namespace Command {
 	export type JSON = CommandJSON;
 	export type Context = AliasPiece.Context;
 	export type RunInTypes = CommandOptionsRunType;
+	export type Interaction = CommandInteraction;
+	export type Registry = ApplicationCommandRegistry;
 }
 
 export type DetailedDescriptionCommand = string | DetailedDescriptionCommandObject;

--- a/src/lib/structures/Command.ts
+++ b/src/lib/structures/Command.ts
@@ -805,7 +805,7 @@ export namespace Command {
 	export type JSON = CommandJSON;
 	export type Context = AliasPiece.Context;
 	export type RunInTypes = CommandOptionsRunType;
-	export type ChatInputInteraction = CommandInteraction;
+	export type ChatInputInteraction = import('discord.js').CommandInteraction;
 	export type ContextMenuInteraction = import('discord.js').ContextMenuInteraction;
 	export type AutocompleteInteraction = import('discord.js').AutocompleteInteraction;
 	export type Registry = ApplicationCommandRegistry;

--- a/src/lib/structures/Command.ts
+++ b/src/lib/structures/Command.ts
@@ -489,6 +489,8 @@ export namespace ChatInputCommand {
 	export type Context = AliasPiece.Context;
 	export type RunInTypes = CommandOptionsRunType;
 	export type RunContext = ChatInputCommandContext;
+	export type Interaction = CommandInteraction;
+	export type Registry = ApplicationCommandRegistry;
 }
 
 export type ContextMenuCommand = Command & Required<Pick<Command, 'contextMenuRun'>>;
@@ -499,6 +501,8 @@ export namespace ContextMenuCommand {
 	export type Context = AliasPiece.Context;
 	export type RunInTypes = CommandOptionsRunType;
 	export type RunContext = ContextMenuCommandContext;
+	export type Interaction = ContextMenuInteraction;
+	export type Registry = ApplicationCommandRegistry;
 }
 
 export type AutocompleteCommand = Command & Required<Pick<Command, 'autocompleteRun'>>;
@@ -509,6 +513,8 @@ export namespace AutocompleteCommand {
 	export type Context = AliasPiece.Context;
 	export type RunInTypes = CommandOptionsRunType;
 	export type RunContext = AutocompleteCommandContext;
+	export type Interaction = AutocompleteInteraction;
+	export type Registry = ApplicationCommandRegistry;
 }
 
 /**

--- a/src/lib/structures/Command.ts
+++ b/src/lib/structures/Command.ts
@@ -806,8 +806,8 @@ export namespace Command {
 	export type Context = AliasPiece.Context;
 	export type RunInTypes = CommandOptionsRunType;
 	export type ChatInputInteraction = CommandInteraction;
-	export type ContextMenuInteraction = ContextMenuInteraction;
-	export type AutocompleteInteraction = AutocompleteInteraction;
+	export type ContextMenuInteraction = import('discord.js').ContextMenuInteraction;
+	export type AutocompleteInteraction = import('discord.js').AutocompleteInteraction;
 	export type Registry = ApplicationCommandRegistry;
 }
 


### PR DESCRIPTION
These namespace members would be great utilities to prevent having to import the registry and interaction every time. (Or doing something like `...[interaction]: Parameters<ChatInputCommand['chatInputRun']>`)