### PR TITLE
feat: add "French Quotes" (`«`, `»`) support for quoted args

### DIFF
--- a/src/lib/structures/Command.ts
+++ b/src/lib/structures/Command.ts
@@ -97,7 +97,8 @@ export class Command<PreParseReturn = Args, O extends Command.Options = Command.
 			options.quotes ?? [
 				['"', '"'], // Double quotes
 				['“', '”'], // Fancy quotes (on iOS)
-				['「', '」'] // Corner brackets (CJK)
+				['「', '」'], // Corner brackets (CJK)
+				['«', '»'] // French quotes (guillemets)
 			]
 		);
 

--- a/tests/Flags.test.ts
+++ b/tests/Flags.test.ts
@@ -7,7 +7,8 @@ const parse = (testString: string) =>
 			.setQuotes([
 				['"', '"'],
 				['“', '”'],
-				['「', '」']
+				['「', '」'],
+				['«', '»']
 			])
 			.lex()
 	)


### PR DESCRIPTION
French people, and many other languages as a matter of fact, use "« »" as quotation marks too.