### PR TITLE
feat(events): add jsdoc description to event enum members

### DIFF
--- a/src/lib/types/Events.ts
+++ b/src/lib/types/Events.ts
@@ -85,74 +85,281 @@ export const Events = {
 
 	// #region Sapphire events
 	// Message commands chain
+	/**
+	 * Emitted when a message is created that was not sent by bots or webhooks.
+	 * @param {Message} message The created message
+	 */
 	PreMessageParsed: 'preMessageParsed' as const,
+	/**
+	 * Emitted when a message is created consisting of only the bot's mention.
+	 * @param {Message} message The created message
+	 */
 	MentionPrefixOnly: 'mentionPrefixOnly' as const,
+	/**
+	 * Emitted when a message is created that does not start with a valid prefix.
+	 * @param {Message} message The created message
+	 */
 	NonPrefixedMessage: 'nonPrefixedMessage' as const,
+	/**
+	 * Emitted when a message is created that does starts with a valid prefix.
+	 * @param {Message} message The created message
+	 */
 	PrefixedMessage: 'prefixedMessage' as const,
 
+	/**
+	 * Emitted when a message starts with a valid prefix but does not include a command name.
+	 * @param {UnknownMessageCommandNamePayload} payload
+	 */
 	UnknownMessageCommandName: 'unknownMessageCommandName' as const,
+	/**
+	 * Emitted when the name of a sent message command does not match any loaded commands.
+	 * @param {UnknownMessageCommandPayload} payload The contextual payload
+	 */
 	UnknownMessageCommand: 'unknownMessageCommand' as const,
+	/**
+	 * Emitted when a message command is executed but a `messageRun` method is not found.
+	 * @param {CommandDoesNotHaveMessageCommandHandler} payload The contextual payload
+	 */
 	CommandDoesNotHaveMessageCommandHandler: 'commandDoesNotHaveMessageCommandHandler' as const,
+	/**
+	 * Emitted before the `messageRun` method of a command is run.
+	 * @param {PreMessageCommandRunPayload} payload The contextual payload
+	 */
 	PreMessageCommandRun: 'preMessageCommandRun' as const,
 
+	/**
+	 * Emitted when a precondition denies a message command from being run.
+	 * @param {UserError} error The error reported by the precondition
+	 * @param {MessageCommandDeniedPayload} payload The contextual payload
+	 */
 	MessageCommandDenied: 'messageCommandDenied' as const,
+	/**
+	 * Emitted when a message command passes all precondition checks, if any.
+	 * @param {MessageCommandAcceptedPayload} payload The contextual payload
+	 */
 	MessageCommandAccepted: 'messageCommandAccepted' as const,
 
+	/**
+	 * Emitted directly before a message command is run.
+	 * @param {Message} message The message that executed the command
+	 * @param {Command} command The command that is being run
+	 * @param {MessageCommandRunPayload} payload The contextual payload
+	 */
 	MessageCommandRun: 'messageCommandRun' as const,
+	/**
+	 * Emitted after a message command runs successfully.
+	 * @param {MessageCommandSuccessPayload} payload The contextual payload
+	 */
 	MessageCommandSuccess: 'messageCommandSuccess' as const,
+	/**
+	 * Emitted after a message command runs unsuccesfully.
+	 * @param {*} error The error that was thrown
+	 * @param {MessageCommandErrorPayload} payload The contextual payload
+	 */
 	MessageCommandError: 'messageCommandError' as const,
+	/**
+	 * Emitted directly after a message command finished running, regardless of the outcome.
+	 * @param {Message} message The message that executed the command
+	 * @param {Command} command The command that finished running
+	 * @param {MessageCommandFinishPayload} payload The contextual payload
+	 */
 	MessageCommandFinish: 'messageCommandFinish' as const,
 
+	/**
+	 * Emitted after the bot unsuccessfully tried to start typing when a command is executed.
+	 * @param error The error that was thrown
+	 * @param payload The contextual payload
+	 */
 	MessageCommandTypingError: 'messageCommandTypingError' as const,
 
 	// Listener errors
+	/**
+	 * Emitted when an error is encountered when executing a listener.
+	 * @param {*} error The error that was thrown
+	 * @param {ListenerErrorPayload} payload The contextual payload
+	 */
 	ListenerError: 'listenerError' as const,
 
 	// Registry errors
+	/**
+	 * Emitted when an error is encountered when handling the command application command registry.
+	 * @param {*} error The error that was thrown
+	 * @param {Command} command The command who's registry caused the error
+	 */
 	CommandApplicationCommandRegistryError: 'commandApplicationCommandRegistryError' as const,
 
 	// Piece store?
+	/**
+	 * Emitted after a piece is loaded.
+	 * @param {Store<Piece>} store The store in which the piece belongs to
+	 * @param {Piece} piece The piece that was loaded
+	 */
 	PiecePostLoad: 'piecePostLoad' as const,
+	/**
+	 * Emitted when a piece is unloaded.
+	 * @param {Store<Piece>} store The store in which the piece belongs to
+	 * @param {Piece} piece The piece that was unloaded
+	 */
 	PieceUnload: 'pieceUnload' as const,
 
 	// Plugin
+	/**
+	 * Emitted when a plugin is loaded.
+	 * @param {PluginHook} hook The plugin hook that was loaded
+	 * @param {string | undefined} name The name of the plugin, if any
+	 */
 	PluginLoaded: 'pluginLoaded' as const,
 
 	// Interaction handlers
+	/**
+	 * Emitted when the `parse` method of an interaction handler encounters an error.
+	 * @param {*} error The error that was encountered
+	 * @param {InteractionHandlerParseError} payload The contextual payload
+	 */
 	InteractionHandlerParseError: 'interactionHandlerParseError' as const,
+	/**
+	 * Emitted when an error is encountered when executing an interaction handler.
+	 * @param {*} error The error that was encountered
+	 * @param {InteractionHandlerError} payload The contextual payload
+	 */
 	InteractionHandlerError: 'interactionHandlerError' as const,
 
 	// Autocomplete interaction
+	/**
+	 * Emitted when an autocomplete interaction is recieved.
+	 * @param {AutocompleteInteraction} interaction The interaction that was recieved
+	 */
 	PossibleAutocompleteInteraction: 'possibleAutocompleteInteraction' as const,
+	/**
+	 * Emitted after an autocomplete interaction handler runs successfully.
+	 * @param {AutocompleteInteractionPayload} payload The contextual payload
+	 */
 	CommandAutocompleteInteractionSuccess: 'commandAutocompleteInteractionSuccess' as const,
+	/**
+	 * Emitted when an error is encountered when executing an autocomplete interaction handler.
+	 * @param {*} error The error that was encountered
+	 * @param {AutocompleteInteractionPayload} payload The contextual payload
+	 */
 	CommandAutocompleteInteractionError: 'commandAutocompleteInteractionError' as const,
 
 	// Chat input command chain
+	/**
+	 * Emitted when a chat input command interaction is recieved.
+	 * @param {CommandInteraction} interaction The interaction that was recieved.
+	 */
 	PossibleChatInputCommand: 'possibleChatInputCommand' as const,
+	/**
+	 * Emitted when the name of a sent chat input command does not match any loaded commands.
+	 * @param {UnknownChatInputCommandPayload} payload The contextual payload
+	 */
 	UnknownChatInputCommand: 'unknownChatInputCommand' as const,
+	/**
+	 * Emitted when a chat input command is executed but a `chatInputRun` method is not found.
+	 * @param {CommandDoesNotHaveChatInputCommandHandlerPayload} payload The contextual payload
+	 */
 	CommandDoesNotHaveChatInputCommandHandler: 'commandDoesNotHaveChatInputCommandHandler' as const,
+	/**
+	 * Emitted before the `chatInputRun` method of a command is run.
+	 * @param {PreChatInputCommandRunPayload} payload The contextual payload
+	 */
 	PreChatInputCommandRun: 'preChatInputCommandRun' as const,
 
+	/**
+	 * Emitted when a precondition denies a chat input command from being run.
+	 * @param {UserError} error The error reported by the precondition
+	 * @param {ChatInputCommandDeniedPayload} payload The contextual payload
+	 */
 	ChatInputCommandDenied: 'chatInputCommandDenied' as const,
+	/**
+	 * Emitted when a chat input command passes all precondition checks, if any.
+	 * @param {ChatInputCommandAcceptedPayload} payload The contextual payload
+	 */
 	ChatInputCommandAccepted: 'chatInputCommandAccepted' as const,
 
+	/**
+	 * Emitted directly before a chat input command is run.
+	 * @param {CommandInteraction} interaction The interaction that executed the command
+	 * @param {ChatInputCommand} command The command that is being run
+	 * @param {ChatInputCommandRunPayload} payload The contextual payload
+	 */
 	ChatInputCommandRun: 'chatInputCommandRun' as const,
+	/**
+	 * Emitted after a chat input command runs successfully.
+	 * @param {ChatInputCommandSuccessPayload} payload The contextual payload
+	 */
 	ChatInputCommandSuccess: 'chatInputCommandSuccess' as const,
+	/**
+	 * Emitted after a chat input command runs unsuccesfully.
+	 * @param {*} error The error that was thrown
+	 * @param {ChatInputCommandErrorPayload} payload The contextual payload
+	 */
 	ChatInputCommandError: 'chatInputCommandError' as const,
+	/**
+	 * Emitted directly after a chat input command finished running, regardless of the outcome.
+	 * @param {Interaction} interaction The interaction that executed the command
+	 * @param {ChatInputCommand} command The command that finished running
+	 * @param {ChatInputCommandFinishPayload} payload The contextual payload
+	 */
 	ChatInputCommandFinish: 'chatInputCommandFinish' as const,
 
 	// Context menu chain
+	/**
+	 * Emitted when a context menu interaction is recieved.
+	 * @param {ContextMenuInteraction} interaction The interaction that was recieved.
+	 */
 	PossibleContextMenuCommand: 'possibleContextMenuCommand' as const,
+	/**
+	 * Emitted when the name of a sent context menu command does not match any loaded commands.
+	 * @param {UnknownContextMenuCommandPayload} payload The contextual payload
+	 */
 	UnknownContextMenuCommand: 'unknownContextMenuCommand' as const,
+	/**
+	 * Emitted when a chat input command is executed but a `contextMenuRun` method is not found.
+	 * @param {CommandDoesNotHaveContextMenuCommandHandlerPayload} payload The contextual payload
+	 */
 	CommandDoesNotHaveContextMenuCommandHandler: 'commandDoesNotHaveContextMenuCommandHandler' as const,
+	/**
+	 * Emitted before the `contextMenuRun` method of a command is run.
+	 * @param {PreContextMenuCommandRunPayload} payload The contextual payload
+	 */
 	PreContextMenuCommandRun: 'preContextMenuCommandRun' as const,
 
+	/**
+	 * Emitted when a precondition denies a context menu command from being run.
+	 * @param {UserError} error The error reported by the precondition
+	 * @param {ContextMenuCommandDeniedPayload} payload The contextual payload
+	 */
 	ContextMenuCommandDenied: 'contextMenuCommandDenied' as const,
+	/**
+	 * Emitted when a context menu command passes all precondition checks, if any.
+	 * @param {ContextMenuCommandAcceptedPayload} payload The contextual payload
+	 */
 	ContextMenuCommandAccepted: 'contextMenuCommandAccepted' as const,
 
+	/**
+	 * Emitted directly before a context menu command is run.
+	 * @param {ContextMenuInteraction} interaction The interaction that executed the command
+	 * @param {ContextMenuCommand} command The command that is being run
+	 * @param {ContextMenuCommandRunPayload} payload The contextual payload
+	 */
 	ContextMenuCommandRun: 'contextMenuCommandRun' as const,
+	/**
+	 * Emitted after a context menu command runs successfully.
+	 * @param {ContextMenuCommandSuccessPayload} payload The contextual payload
+	 */
 	ContextMenuCommandSuccess: 'contextMenuCommandSuccess' as const,
+	/**
+	 * Emitted after a context menu command runs unsuccesfully.
+	 * @param {*} error The error that was thrown
+	 * @param {ContextMenuCommandErrorPayload} payload The contextual payload
+	 */
 	ContextMenuCommandError: 'contextMenuCommandError' as const,
+	/**
+	 * Emitted directly after a context menu command finished running, regardless of the outcome.
+	 * @param {Interaction} interaction The interaction that executed the command
+	 * @param {ContextMenuCommand} command The command that finished running
+	 * @param {ContextMenuCommandFinishPayload} payload The contextual payload
+	 */
 	ContextMenuCommandFinish: 'contextMenuCommandFinish' as const
 
 	// #endregion Sapphire events


### PR DESCRIPTION
I found that *CommandRun and *CommandFinish `command` args used specific `*Command` types for chat input and context menu, but not message. Should I change that?