### PR TITLE
refactor: cleanup and proper `/pieces@3.4.0` support

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,11 +32,11 @@
 		"@sapphire/discord-utilities": "^2.11.5",
 		"@sapphire/discord.js-utilities": "^4.11.3",
 		"@sapphire/lexure": "^1.0.1",
-		"@sapphire/pieces": "^3.4.0",
+		"@sapphire/pieces": "^3.4.1",
 		"@sapphire/ratelimits": "^2.4.4",
 		"@sapphire/result": "^2.2.0",
 		"@sapphire/stopwatch": "^1.4.1",
-		"@sapphire/utilities": "^3.8.0",
+		"@sapphire/utilities": "^3.9.0",
 		"@types/object-hash": "^2.2.1",
 		"object-hash": "^3.0.0",
 		"tslib": "^2.4.0"

--- a/src/lib/SapphireClient.ts
+++ b/src/lib/SapphireClient.ts
@@ -37,7 +37,7 @@ export interface SapphireClientOptions {
 	 * @since 1.0.0
 	 * @default undefined
 	 */
-	baseUserDirectory?: string | null;
+	baseUserDirectory?: URL | string | null;
 
 	/**
 	 * Whether commands can be case insensitive

--- a/src/lib/structures/ArgumentStore.ts
+++ b/src/lib/structures/ArgumentStore.ts
@@ -3,6 +3,6 @@ import { Argument } from './Argument';
 
 export class ArgumentStore extends AliasStore<Argument> {
 	public constructor() {
-		super(Argument as any, { name: 'arguments' });
+		super(Argument, { name: 'arguments' });
 	}
 }

--- a/src/lib/structures/Command.ts
+++ b/src/lib/structures/Command.ts
@@ -1,4 +1,5 @@
-import { AliasPiece, AliasPieceJSON, AliasStore, PieceContext } from '@sapphire/pieces';
+import { ArgumentStream, IUnorderedStrategy, Lexer, Parser } from '@sapphire/lexure';
+import { AliasPiece, AliasPieceJSON, AliasStore } from '@sapphire/pieces';
 import { Awaitable, isNullish, NonNullObject } from '@sapphire/utilities';
 import type { LocalizationMap } from 'discord-api-types/v10';
 import {
@@ -10,7 +11,6 @@ import {
 	Permissions,
 	Snowflake
 } from 'discord.js';
-import { ArgumentStream, IUnorderedStrategy, Lexer, Parser } from '@sapphire/lexure';
 import { Args } from '../parsers/Args';
 import { BucketScope, RegisterBehavior } from '../types/Enums';
 import { acquire } from '../utils/application-commands/ApplicationCommandRegistries';
@@ -80,7 +80,7 @@ export class Command<PreParseReturn = Args, O extends Command.Options = Command.
 	 * @param context The context.
 	 * @param options Optional Command settings.
 	 */
-	protected constructor(context: PieceContext, options: O = {} as O) {
+	public constructor(context: AliasPiece.Context, options: O = {} as O) {
 		super(context, { ...options, name: (options.name ?? context.name).toLowerCase() });
 		this.description = options.description ?? '';
 		this.detailedDescription = options.detailedDescription ?? '';

--- a/src/lib/structures/CommandStore.ts
+++ b/src/lib/structures/CommandStore.ts
@@ -9,7 +9,7 @@ import { Command } from './Command';
  */
 export class CommandStore extends AliasStore<Command> {
 	public constructor() {
-		super(Command as any, { name: 'commands' });
+		super(Command, { name: 'commands' });
 	}
 
 	/**

--- a/src/lib/structures/InteractionHandler.ts
+++ b/src/lib/structures/InteractionHandler.ts
@@ -1,4 +1,4 @@
-import { Piece, PieceContext, PieceJSON, PieceOptions } from '@sapphire/pieces';
+import { Piece, PieceJSON, PieceOptions } from '@sapphire/pieces';
 import { Option } from '@sapphire/result';
 import type { Awaitable } from '@sapphire/utilities';
 import type { Interaction } from 'discord.js';
@@ -10,7 +10,7 @@ export abstract class InteractionHandler<O extends InteractionHandler.Options = 
 	 */
 	public readonly interactionHandlerType: InteractionHandlerTypes;
 
-	public constructor(context: PieceContext, options: InteractionHandlerOptions) {
+	public constructor(context: Piece.Context, options: InteractionHandlerOptions) {
 		super(context, options);
 
 		this.interactionHandlerType = options.interactionHandlerType;
@@ -97,7 +97,7 @@ export interface InteractionHandlerJSON extends PieceJSON {
 export type InteractionHandlerParseResult<Instance extends InteractionHandler> = Option.UnwrapSome<Awaited<ReturnType<Instance['parse']>>>;
 
 export namespace InteractionHandler {
-	export type Context = PieceContext;
+	export type Context = Piece.Context;
 	export type Options = InteractionHandlerOptions;
 	export type JSON = InteractionHandlerJSON;
 	export type ParseResult<Instance extends InteractionHandler> = InteractionHandlerParseResult<Instance>;

--- a/src/lib/structures/InteractionHandlerStore.ts
+++ b/src/lib/structures/InteractionHandlerStore.ts
@@ -6,7 +6,7 @@ import { InteractionHandler, InteractionHandlerTypes, type InteractionHandlerOpt
 
 export class InteractionHandlerStore extends Store<InteractionHandler> {
 	public constructor() {
-		super(InteractionHandler as any, { name: 'interaction-handlers' });
+		super(InteractionHandler, { name: 'interaction-handlers' });
 	}
 
 	public async run(interaction: Interaction) {

--- a/src/lib/structures/ListenerStore.ts
+++ b/src/lib/structures/ListenerStore.ts
@@ -3,6 +3,6 @@ import { Listener } from './Listener';
 
 export class ListenerStore extends Store<Listener> {
 	public constructor() {
-		super(Listener as any, { name: 'listeners' });
+		super(Listener, { name: 'listeners' });
 	}
 }

--- a/src/lib/structures/PreconditionStore.ts
+++ b/src/lib/structures/PreconditionStore.ts
@@ -9,7 +9,7 @@ export class PreconditionStore extends Store<Precondition> {
 	private readonly globalPreconditions: Precondition[] = [];
 
 	public constructor() {
-		super(Precondition as any, { name: 'preconditions' });
+		super(Precondition, { name: 'preconditions' });
 	}
 
 	public async messageRun(message: Message, command: MessageCommand, context: PreconditionContext = {}): AsyncPreconditionResult {

--- a/src/lib/utils/preconditions/containers/ClientPermissionsPrecondition.ts
+++ b/src/lib/utils/preconditions/containers/ClientPermissionsPrecondition.ts
@@ -7,7 +7,7 @@ import type { PreconditionSingleResolvableDetails } from '../PreconditionContain
  * @example
  * ```typescript
  * export class CoreCommand extends Command {
- *   public constructor(context: PieceContext) {
+ *   public constructor(context: Command.Context) {
  *     super(context, {
  *       preconditions: [
  *         'GuildOnly',

--- a/src/lib/utils/preconditions/containers/UserPermissionsPrecondition.ts
+++ b/src/lib/utils/preconditions/containers/UserPermissionsPrecondition.ts
@@ -7,7 +7,7 @@ import type { PreconditionSingleResolvableDetails } from '../PreconditionContain
  * @example
  * ```typescript
  * export class CoreCommand extends Command {
- *   public constructor(context: PieceContext) {
+ *   public constructor(context: Command.Context) {
  *     super(context, {
  *       preconditions: [
  *         'GuildOnly',

--- a/src/listeners/CoreInteractionCreate.ts
+++ b/src/listeners/CoreInteractionCreate.ts
@@ -1,10 +1,9 @@
-import type { PieceContext } from '@sapphire/pieces';
 import type { Interaction } from 'discord.js';
 import { Listener } from '../lib/structures/Listener';
 import { Events } from '../lib/types/Events';
 
 export class CoreEvent extends Listener<typeof Events.InteractionCreate> {
-	public constructor(context: PieceContext) {
+	public constructor(context: Listener.Context) {
 		super(context, { event: Events.InteractionCreate });
 	}
 

--- a/src/listeners/CoreReady.ts
+++ b/src/listeners/CoreReady.ts
@@ -1,10 +1,9 @@
-import type { PieceContext } from '@sapphire/pieces';
 import { Listener } from '../lib/structures/Listener';
 import { Events } from '../lib/types/Events';
 import { handleRegistryAPICalls } from '../lib/utils/application-commands/ApplicationCommandRegistries';
 
 export class CoreEvent extends Listener {
-	public constructor(context: PieceContext) {
+	public constructor(context: Listener.Context) {
 		super(context, { event: Events.ClientReady, once: true });
 	}
 

--- a/src/listeners/application-commands/CorePossibleAutocompleteInteraction.ts
+++ b/src/listeners/application-commands/CorePossibleAutocompleteInteraction.ts
@@ -1,11 +1,10 @@
-import type { PieceContext } from '@sapphire/pieces';
 import type { AutocompleteInteraction } from 'discord.js';
 import type { AutocompleteCommand } from '../../lib/structures/Command';
 import { Listener } from '../../lib/structures/Listener';
 import { Events } from '../../lib/types/Events';
 
 export class CoreListener extends Listener<typeof Events.PossibleAutocompleteInteraction> {
-	public constructor(context: PieceContext) {
+	public constructor(context: Listener.Context) {
 		super(context, { event: Events.PossibleAutocompleteInteraction });
 	}
 

--- a/src/listeners/application-commands/chat-input/CoreChatInputCommandAccepted.ts
+++ b/src/listeners/application-commands/chat-input/CoreChatInputCommandAccepted.ts
@@ -1,11 +1,10 @@
-import type { PieceContext } from '@sapphire/pieces';
 import { Result } from '@sapphire/result';
 import { Stopwatch } from '@sapphire/stopwatch';
 import { Listener } from '../../../lib/structures/Listener';
 import { ChatInputCommandAcceptedPayload, Events } from '../../../lib/types/Events';
 
 export class CoreListener extends Listener<typeof Events.ChatInputCommandAccepted> {
-	public constructor(context: PieceContext) {
+	public constructor(context: Listener.Context) {
 		super(context, { event: Events.ChatInputCommandAccepted });
 	}
 

--- a/src/listeners/application-commands/chat-input/CorePossibleChatInputCommand.ts
+++ b/src/listeners/application-commands/chat-input/CorePossibleChatInputCommand.ts
@@ -1,11 +1,10 @@
-import type { PieceContext } from '@sapphire/pieces';
 import type { CommandInteraction } from 'discord.js';
 import type { ChatInputCommand } from '../../../lib/structures/Command';
 import { Listener } from '../../../lib/structures/Listener';
 import { Events } from '../../../lib/types/Events';
 
 export class CoreListener extends Listener<typeof Events.PossibleChatInputCommand> {
-	public constructor(context: PieceContext) {
+	public constructor(context: Listener.Context) {
 		super(context, { event: Events.PossibleChatInputCommand });
 	}
 

--- a/src/listeners/application-commands/chat-input/CorePreChatInputCommandRun.ts
+++ b/src/listeners/application-commands/chat-input/CorePreChatInputCommandRun.ts
@@ -1,9 +1,8 @@
-import type { PieceContext } from '@sapphire/pieces';
 import { Listener } from '../../../lib/structures/Listener';
 import { Events, PreChatInputCommandRunPayload } from '../../../lib/types/Events';
 
 export class CoreListener extends Listener<typeof Events.PreChatInputCommandRun> {
-	public constructor(context: PieceContext) {
+	public constructor(context: Listener.Context) {
 		super(context, { event: Events.PreChatInputCommandRun });
 	}
 

--- a/src/listeners/application-commands/context-menu/CoreContextMenuCommandAccepted.ts
+++ b/src/listeners/application-commands/context-menu/CoreContextMenuCommandAccepted.ts
@@ -1,11 +1,10 @@
-import type { PieceContext } from '@sapphire/pieces';
 import { Result } from '@sapphire/result';
 import { Stopwatch } from '@sapphire/stopwatch';
 import { Listener } from '../../../lib/structures/Listener';
 import { ContextMenuCommandAcceptedPayload, Events } from '../../../lib/types/Events';
 
 export class CoreListener extends Listener<typeof Events.ContextMenuCommandAccepted> {
-	public constructor(context: PieceContext) {
+	public constructor(context: Listener.Context) {
 		super(context, { event: Events.ContextMenuCommandAccepted });
 	}
 

--- a/src/listeners/application-commands/context-menu/CorePossibleContextMenuCommand.ts
+++ b/src/listeners/application-commands/context-menu/CorePossibleContextMenuCommand.ts
@@ -1,11 +1,10 @@
-import type { PieceContext } from '@sapphire/pieces';
 import type { ContextMenuInteraction } from 'discord.js';
 import type { ContextMenuCommand } from '../../../lib/structures/Command';
 import { Listener } from '../../../lib/structures/Listener';
 import { Events } from '../../../lib/types/Events';
 
 export class CoreListener extends Listener<typeof Events.PossibleContextMenuCommand> {
-	public constructor(context: PieceContext) {
+	public constructor(context: Listener.Context) {
 		super(context, { event: Events.PossibleContextMenuCommand });
 	}
 

--- a/src/listeners/application-commands/context-menu/CorePreContextMenuCommandRun.ts
+++ b/src/listeners/application-commands/context-menu/CorePreContextMenuCommandRun.ts
@@ -1,9 +1,8 @@
-import type { PieceContext } from '@sapphire/pieces';
 import { Listener } from '../../../lib/structures/Listener';
 import { Events, PreContextMenuCommandRunPayload } from '../../../lib/types/Events';
 
 export class CoreListener extends Listener<typeof Events.PreContextMenuCommandRun> {
-	public constructor(context: PieceContext) {
+	public constructor(context: Listener.Context) {
 		super(context, { event: Events.PreContextMenuCommandRun });
 	}
 

--- a/src/optional-listeners/error-listeners/CoreChatInputCommandError.ts
+++ b/src/optional-listeners/error-listeners/CoreChatInputCommandError.ts
@@ -1,9 +1,8 @@
-import type { PieceContext } from '@sapphire/pieces';
 import { Listener } from '../../lib/structures/Listener';
 import { ChatInputCommandErrorPayload, Events } from '../../lib/types/Events';
 
 export class CoreEvent extends Listener<typeof Events.ChatInputCommandError> {
-	public constructor(context: PieceContext) {
+	public constructor(context: Listener.Context) {
 		super(context, { event: Events.ChatInputCommandError });
 	}
 

--- a/src/optional-listeners/error-listeners/CoreCommandApplicationCommandRegistryError.ts
+++ b/src/optional-listeners/error-listeners/CoreCommandApplicationCommandRegistryError.ts
@@ -1,10 +1,9 @@
-import type { PieceContext } from '@sapphire/pieces';
 import type { Command } from '../../lib/structures/Command';
 import { Listener } from '../../lib/structures/Listener';
 import { Events } from '../../lib/types/Events';
 
 export class CoreEvent extends Listener<typeof Events.CommandApplicationCommandRegistryError> {
-	public constructor(context: PieceContext) {
+	public constructor(context: Listener.Context) {
 		super(context, { event: Events.CommandApplicationCommandRegistryError });
 	}
 

--- a/src/optional-listeners/error-listeners/CoreCommandAutocompleteInteractionError.ts
+++ b/src/optional-listeners/error-listeners/CoreCommandAutocompleteInteractionError.ts
@@ -1,9 +1,8 @@
-import type { PieceContext } from '@sapphire/pieces';
 import { Listener } from '../../lib/structures/Listener';
 import { AutocompleteInteractionPayload, Events } from '../../lib/types/Events';
 
 export class CoreEvent extends Listener<typeof Events.CommandAutocompleteInteractionError> {
-	public constructor(context: PieceContext) {
+	public constructor(context: Listener.Context) {
 		super(context, { event: Events.CommandAutocompleteInteractionError });
 	}
 

--- a/src/optional-listeners/error-listeners/CoreContextMenuCommandError.ts
+++ b/src/optional-listeners/error-listeners/CoreContextMenuCommandError.ts
@@ -1,9 +1,8 @@
-import type { PieceContext } from '@sapphire/pieces';
 import { Listener } from '../../lib/structures/Listener';
 import { ContextMenuCommandErrorPayload, Events } from '../../lib/types/Events';
 
 export class CoreEvent extends Listener<typeof Events.ContextMenuCommandError> {
-	public constructor(context: PieceContext) {
+	public constructor(context: Listener.Context) {
 		super(context, { event: Events.ContextMenuCommandError });
 	}
 

--- a/src/optional-listeners/error-listeners/CoreInteractionHandlerError.ts
+++ b/src/optional-listeners/error-listeners/CoreInteractionHandlerError.ts
@@ -1,9 +1,8 @@
-import type { PieceContext } from '@sapphire/pieces';
 import { Listener } from '../../lib/structures/Listener';
 import { Events, InteractionHandlerError } from '../../lib/types/Events';
 
 export class CoreEvent extends Listener<typeof Events.InteractionHandlerError> {
-	public constructor(context: PieceContext) {
+	public constructor(context: Listener.Context) {
 		super(context, { event: Events.InteractionHandlerError });
 	}
 

--- a/src/optional-listeners/error-listeners/CoreInteractionHandlerParseError.ts
+++ b/src/optional-listeners/error-listeners/CoreInteractionHandlerParseError.ts
@@ -1,9 +1,8 @@
-import type { PieceContext } from '@sapphire/pieces';
 import { Listener } from '../../lib/structures/Listener';
 import { Events, InteractionHandlerParseError as InteractionHandlerParseErrorPayload } from '../../lib/types/Events';
 
 export class CoreEvent extends Listener<typeof Events.InteractionHandlerParseError> {
-	public constructor(context: PieceContext) {
+	public constructor(context: Listener.Context) {
 		super(context, { event: Events.InteractionHandlerParseError });
 	}
 

--- a/src/optional-listeners/error-listeners/CoreListenerError.ts
+++ b/src/optional-listeners/error-listeners/CoreListenerError.ts
@@ -1,9 +1,8 @@
-import type { PieceContext } from '@sapphire/pieces';
 import { Listener } from '../../lib/structures/Listener';
 import { Events, ListenerErrorPayload } from '../../lib/types/Events';
 
 export class CoreEvent extends Listener<typeof Events.ListenerError> {
-	public constructor(context: PieceContext) {
+	public constructor(context: Listener.Context) {
 		super(context, { event: Events.ListenerError });
 	}
 

--- a/src/optional-listeners/error-listeners/CoreMessageCommandError.ts
+++ b/src/optional-listeners/error-listeners/CoreMessageCommandError.ts
@@ -1,9 +1,8 @@
-import type { PieceContext } from '@sapphire/pieces';
 import { Listener } from '../../lib/structures/Listener';
 import { Events, MessageCommandErrorPayload } from '../../lib/types/Events';
 
 export class CoreEvent extends Listener<typeof Events.MessageCommandError> {
-	public constructor(context: PieceContext) {
+	public constructor(context: Listener.Context) {
 		super(context, { event: Events.MessageCommandError });
 	}
 

--- a/src/optional-listeners/message-command-listeners/CoreMessageCommandAccepted.ts
+++ b/src/optional-listeners/message-command-listeners/CoreMessageCommandAccepted.ts
@@ -1,11 +1,10 @@
-import type { PieceContext } from '@sapphire/pieces';
 import { Result } from '@sapphire/result';
 import { Stopwatch } from '@sapphire/stopwatch';
 import { Listener } from '../../lib/structures/Listener';
 import { Events, MessageCommandAcceptedPayload } from '../../lib/types/Events';
 
 export class CoreListener extends Listener<typeof Events.MessageCommandAccepted> {
-	public constructor(context: PieceContext) {
+	public constructor(context: Listener.Context) {
 		super(context, { event: Events.MessageCommandAccepted });
 	}
 

--- a/src/optional-listeners/message-command-listeners/CoreMessageCommandTyping.ts
+++ b/src/optional-listeners/message-command-listeners/CoreMessageCommandTyping.ts
@@ -1,11 +1,10 @@
-import type { PieceContext } from '@sapphire/pieces';
 import type { Message } from 'discord.js';
 import type { MessageCommand } from '../../lib/structures/Command';
 import { Listener } from '../../lib/structures/Listener';
 import { Events, MessageCommandRunPayload } from '../../lib/types/Events';
 
 export class CoreListener extends Listener<typeof Events.MessageCommandRun> {
-	public constructor(context: PieceContext) {
+	public constructor(context: Listener.Context) {
 		super(context, { event: Events.MessageCommandRun });
 		this.enabled = this.container.client.options.typing ?? false;
 	}

--- a/src/optional-listeners/message-command-listeners/CoreMessageCreate.ts
+++ b/src/optional-listeners/message-command-listeners/CoreMessageCreate.ts
@@ -1,10 +1,9 @@
-import type { PieceContext } from '@sapphire/pieces';
 import type { Message } from 'discord.js';
 import { Listener } from '../../lib/structures/Listener';
 import { Events } from '../../lib/types/Events';
 
 export class CoreListener extends Listener<typeof Events.MessageCreate> {
-	public constructor(context: PieceContext) {
+	public constructor(context: Listener.Context) {
 		super(context, { event: Events.MessageCreate });
 	}
 

--- a/src/optional-listeners/message-command-listeners/CorePreMessageCommandRun.ts
+++ b/src/optional-listeners/message-command-listeners/CorePreMessageCommandRun.ts
@@ -1,9 +1,8 @@
-import type { PieceContext } from '@sapphire/pieces';
 import { Listener } from '../../lib/structures/Listener';
 import { Events, PreMessageCommandRunPayload } from '../../lib/types/Events';
 
 export class CoreListener extends Listener<typeof Events.PreMessageCommandRun> {
-	public constructor(context: PieceContext) {
+	public constructor(context: Listener.Context) {
 		super(context, { event: Events.PreMessageCommandRun });
 	}
 

--- a/src/optional-listeners/message-command-listeners/CorePreMessageParser.ts
+++ b/src/optional-listeners/message-command-listeners/CorePreMessageParser.ts
@@ -1,5 +1,4 @@
 import { GuildBasedChannelTypes, isDMChannel } from '@sapphire/discord.js-utilities';
-import type { PieceContext } from '@sapphire/pieces';
 import { Message, Permissions } from 'discord.js';
 import { Listener } from '../../lib/structures/Listener';
 import { Events } from '../../lib/types/Events';
@@ -7,7 +6,7 @@ import { Events } from '../../lib/types/Events';
 export class CoreListener extends Listener<typeof Events.PreMessageParsed> {
 	private readonly requiredPermissions = new Permissions(['VIEW_CHANNEL', 'SEND_MESSAGES']).freeze();
 
-	public constructor(context: PieceContext) {
+	public constructor(context: Listener.Context) {
 		super(context, { event: Events.PreMessageParsed });
 	}
 

--- a/src/optional-listeners/message-command-listeners/CorePrefixedMessage.ts
+++ b/src/optional-listeners/message-command-listeners/CorePrefixedMessage.ts
@@ -1,11 +1,10 @@
-import type { PieceContext } from '@sapphire/pieces';
 import type { Message } from 'discord.js';
 import type { MessageCommand } from '../../lib/structures/Command';
 import { Listener } from '../../lib/structures/Listener';
 import { Events } from '../../lib/types/Events';
 
 export class CoreListener extends Listener<typeof Events.PrefixedMessage> {
-	public constructor(context: PieceContext) {
+	public constructor(context: Listener.Context) {
 		super(context, { event: Events.PrefixedMessage });
 	}
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1144,13 +1144,13 @@ __metadata:
     "@sapphire/discord.js-utilities": ^4.11.3
     "@sapphire/eslint-config": ^4.3.7
     "@sapphire/lexure": ^1.0.1
-    "@sapphire/pieces": ^3.4.0
+    "@sapphire/pieces": ^3.4.1
     "@sapphire/prettier-config": ^1.4.3
     "@sapphire/ratelimits": ^2.4.4
     "@sapphire/result": ^2.2.0
     "@sapphire/stopwatch": ^1.4.1
     "@sapphire/ts-config": ^3.3.4
-    "@sapphire/utilities": ^3.8.0
+    "@sapphire/utilities": ^3.9.0
     "@types/jest": ^28.1.6
     "@types/node": ^18.6.4
     "@types/object-hash": ^2.2.1
@@ -1190,14 +1190,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sapphire/pieces@npm:^3.4.0":
-  version: 3.4.0
-  resolution: "@sapphire/pieces@npm:3.4.0"
+"@sapphire/pieces@npm:^3.4.1":
+  version: 3.4.1
+  resolution: "@sapphire/pieces@npm:3.4.1"
   dependencies:
     "@discordjs/collection": ^1.0.1
-    "@sapphire/utilities": ^3.8.0
+    "@sapphire/utilities": ^3.9.0
     tslib: ^2.4.0
-  checksum: 05d05a5471aa3f049c8b53684e54cd43128fe77831b9a2fec0e94d5934f5c43cb1294ef839f9bfce41511ef4d44e0f484b194c8fce90a5b457ef47a4903f650f
+  checksum: 0e93d597779bc7bbec29d25d5dc043c2ed9725147cde1919784304212afa8deff0eb19631c6bde5f04bc41b2182ccda2274bc48941bb1d6f3d249be74684990c
   languageName: node
   linkType: hard
 
@@ -1264,10 +1264,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sapphire/utilities@npm:^3.6.2, @sapphire/utilities@npm:^3.7.0, @sapphire/utilities@npm:^3.8.0":
-  version: 3.8.0
-  resolution: "@sapphire/utilities@npm:3.8.0"
-  checksum: 5b7520bcce6abf743bdf393783bed7b003e2fe6e6473a8325c00ee1df8c7eb6325ec0a307435345627b609146ca0555e5169545af41c7b3a71dcf6f7b87339f3
+"@sapphire/utilities@npm:^3.6.2, @sapphire/utilities@npm:^3.7.0, @sapphire/utilities@npm:^3.8.0, @sapphire/utilities@npm:^3.9.0":
+  version: 3.9.0
+  resolution: "@sapphire/utilities@npm:3.9.0"
+  checksum: 2d8fdf173abc39d7f8bdeb593daebe8b1e2fb71ffa91951cb4ef57845eec45938bfd1d4f5db2e78a0b9ab212c0d033a4fbefcf6335a28afb8a1cea7f44926160
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Adds support for `URL` in `SapphireClientOptions.baseUserDirectory`
- Removes `as any` from stores
- Makes `Command`'s constructor `public` instead of `protected` (so `AbstractConstructor<Command>` works)
- Replaces `PieceContext` with `Listener.Context` and `Command.Context`, where applicable
