### PR TITLE
fix: reloading the entire command store didn't fire ApplicationCommandRegistries

### DIFF
--- a/src/lib/structures/CommandStore.ts
+++ b/src/lib/structures/CommandStore.ts
@@ -67,11 +67,6 @@ export class CommandStore extends AliasStore<Command> {
 		const { applicationCommands, globalCommands, guildCommands } = await getNeededRegistryParameters(allGuildIdsToFetchCommandsFor);
 
 		for (const command of this.values()) {
-			// Skip commands without any api calls to run
-			if (!command.applicationCommandRegistry['apiCalls'].length) {
-				continue;
-			}
-
 			// eslint-disable-next-line @typescript-eslint/dot-notation
 			await command.applicationCommandRegistry['runAPICalls'](applicationCommands, globalCommands, guildCommands);
 

--- a/src/lib/structures/CommandStore.ts
+++ b/src/lib/structures/CommandStore.ts
@@ -52,8 +52,8 @@ export class CommandStore extends AliasStore<Command> {
 		// If we don't have an application, that means this was called on login...
 		if (!this.container.client.application) return;
 
-		// Unfortunately, we have to have double iterations here as we need all the guild ids before we fetch the needed
-		// registry parameters. Cries in double iterations
+		// super.loadAll() currently deletes all application command registries while unloading old pieces,
+		// re-register application commands to ensure allGuildIdsToFetchCommandsFor has new guild ids for getNeededRegistryParameters
 		for (const command of this.values()) {
 			if (command.registerApplicationCommands) {
 				try {


### PR DESCRIPTION
`CommandStore#loadAll()` indirectly removes all application command registries. In addition, the Command's `applicationCommandRegistry` being readonly snapshots the command's old registry before it is removed.

As a result, application command registries won't handle api calls after reloading the command store more than once.

This is a hacky patch that gets the job done, so draft pr is only for visibility in hopes of reaching a better solution.