### PR TITLE
fix: fixed `args#restResult` including leading space

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ gh
 
 # Ignore the "wiki" folder so we can checkout the wiki inside the same folder
 wiki/
+
+# Ignore build artifacts
+*.tgz

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 		"@discordjs/builders": "^0.16.0",
 		"@sapphire/discord-utilities": "^2.11.6",
 		"@sapphire/discord.js-utilities": "^5.0.0",
-		"@sapphire/lexure": "^1.0.2",
+		"@sapphire/lexure": "^1.1.0",
 		"@sapphire/pieces": "^3.5.1",
 		"@sapphire/ratelimits": "^2.4.4",
 		"@sapphire/result": "^2.4.1",

--- a/src/lib/parsers/Args.ts
+++ b/src/lib/parsers/Args.ts
@@ -204,7 +204,7 @@ export class Args {
 		const data = this.parser
 			.many()
 			.unwrapOr<Parameter[]>([])
-			.reduce((acc, parameter) => `${acc}${parameter.leading}${parameter.value}`, '');
+			.reduce((acc, parameter) => `${acc}${acc === '' ? '' : parameter.leading}${parameter.value}`, '');
 		const result = await argument.run(data, {
 			args: this,
 			argument,

--- a/src/lib/parsers/Args.ts
+++ b/src/lib/parsers/Args.ts
@@ -1,5 +1,5 @@
 import type { ChannelTypes, GuildBasedChannelTypes } from '@sapphire/discord.js-utilities';
-import { ArgumentStream, join, Parameter } from '@sapphire/lexure';
+import { join, type ArgumentStream, type Parameter } from '@sapphire/lexure';
 import { container } from '@sapphire/pieces';
 import { Option, Result } from '@sapphire/result';
 import type { Awaitable } from '@sapphire/utilities';

--- a/src/lib/parsers/Args.ts
+++ b/src/lib/parsers/Args.ts
@@ -1,5 +1,5 @@
 import type { ChannelTypes, GuildBasedChannelTypes } from '@sapphire/discord.js-utilities';
-import type { ArgumentStream, Parameter } from '@sapphire/lexure';
+import { ArgumentStream, join, Parameter } from '@sapphire/lexure';
 import { container } from '@sapphire/pieces';
 import { Option, Result } from '@sapphire/result';
 import type { Awaitable } from '@sapphire/utilities';
@@ -201,10 +201,7 @@ export class Args {
 		if (this.parser.finished) return this.missingArguments();
 
 		const state = this.parser.save();
-		const data = this.parser
-			.many()
-			.unwrapOr<Parameter[]>([])
-			.reduce((acc, parameter) => `${acc}${acc === '' ? '' : parameter.leading}${parameter.value}`, '');
+		const data = join(this.parser.many().unwrapOr<Parameter[]>([]));
 		const result = await argument.run(data, {
 			args: this,
 			argument,

--- a/yarn.lock
+++ b/yarn.lock
@@ -546,7 +546,7 @@ __metadata:
     "@sapphire/discord-utilities": ^2.11.6
     "@sapphire/discord.js-utilities": ^5.0.0
     "@sapphire/eslint-config": ^4.3.8
-    "@sapphire/lexure": ^1.0.2
+    "@sapphire/lexure": ^1.1.0
     "@sapphire/pieces": ^3.5.1
     "@sapphire/prettier-config": ^1.4.4
     "@sapphire/ratelimits": ^2.4.4
@@ -582,12 +582,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@sapphire/lexure@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "@sapphire/lexure@npm:1.0.2"
+"@sapphire/lexure@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@sapphire/lexure@npm:1.1.0"
   dependencies:
     "@sapphire/result": ^2.4.1
-  checksum: 83ffbeb60c93a663bf7eea5677545a6f974744ef5dbc9aad32b7e4684ef2fe11472ffe82455bc326e1f855a154af742c7b3021b4848ff32c8b816636c6dad833
+  checksum: 7c8f9d356c3f7a67c72748561ca0043e41ca8025ca560f918ed677a3add52f2ad0d0196e432317c50e832881bade49dee03e0f957f763965919ebf1ce922e82f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR removes the leading space when using `Args#rest()` and `Args#restResult()` on arguments after the first one. This was achieved by removing the insertion of the `paramater.leading` value on the first reduction done by `Array#reduce()`, but keeping it for all others (if it isn't kept, the result would have no spaces kindalikethis). Test images and the code used to generate the images are below. I also added `*.tgz` to `.gitingore` as that was generated when I used `yarn pack` to test the changes.

<details>
  <summary>Before</summary>

![image](https://user-images.githubusercontent.com/34194692/190875490-4fcad43f-1fbc-434e-b521-b5d36acc1ca8.png)
</details>

<details>
  <summary>After</summary>

![image](https://user-images.githubusercontent.com/34194692/190875497-8fcbef2c-69cf-47d3-83b1-d5fa010d0f9a.png)
</details>

<details>
  <summary>Test command file used</summary>

  ````ts
import { ApplyOptions } from '@sapphire/decorators';
import type { Args } from '@sapphire/framework';
import { send } from '@sapphire/plugin-editable-commands';
import { Subcommand } from '@sapphire/plugin-subcommands';
import type { Message } from 'discord.js';

@ApplyOptions<Subcommand.Options>({
	aliases: ['cws'],
	description: 'A basic command with some subcommands',
	subcommands: [
		{
			name: 'show',
			messageRun: 'sShow'
		},
		{
			name: 'group',
			type: 'group',
			entries: [
				{ name: 'show', messageRun: 'gShow'}
			]
		}
	]
})
export class UserCommand extends Subcommand {

	public async sShow(message: Message, args: Args) {
		return send(message, `Normal subcommand args:\`\`\`${await args.rest('string')}\`\`\``);
	}

	public async gShow(message: Message, args: Args) {
		return send(message, `Group subcommand args:\`\`\`${await args.rest('string')}\`\`\``);
	}
}

  ````
</details>

This PR closes #529 