### PR TITLE
fix(precondition): use result for PreconditionContainerSingle

### DIFF
--- a/src/lib/errors/Identifiers.ts
+++ b/src/lib/errors/Identifiers.ts
@@ -60,6 +60,8 @@ export const enum Identifiers {
 	PreconditionUserPermissionsNoPermissions = 'preconditionUserPermissionsNoPermissions',
 	PreconditionThreadOnly = 'preconditionThreadOnly',
 
+	PreconditionUnavailable = 'preconditionUnavailable',
+
 	PreconditionMissingMessageHandler = 'preconditionMissingMessageHandler',
 	PreconditionMissingChatInputHandler = 'preconditionMissingChatInputHandler',
 	PreconditionMissingContextMenuHandler = 'preconditionMissingContextMenuHandler'

--- a/src/lib/utils/preconditions/PreconditionContainerSingle.ts
+++ b/src/lib/utils/preconditions/PreconditionContainerSingle.ts
@@ -1,5 +1,8 @@
 import { container } from '@sapphire/pieces';
+import { Result } from '@sapphire/result';
 import type { CommandInteraction, ContextMenuInteraction, Message } from 'discord.js';
+import { Identifiers } from '../../errors/Identifiers';
+import { UserError } from '../../errors/UserError';
 import type { ChatInputCommand, ContextMenuCommand, MessageCommand } from '../../structures/Command';
 import type { PreconditionContext, PreconditionKeys, Preconditions, SimplePreconditionKeys } from '../../structures/Precondition';
 import type { IPreconditionContainer } from './IPreconditionContainer';
@@ -77,15 +80,19 @@ export class PreconditionContainerSingle implements IPreconditionContainer {
 	 * @param message The message that ran this precondition.
 	 * @param command The command the message invoked.
 	 */
-	public messageRun(message: Message, command: MessageCommand, context: PreconditionContext = {}) {
+	public async messageRun(message: Message, command: MessageCommand, context: PreconditionContext = {}) {
 		const precondition = container.stores.get('preconditions').get(this.name);
 		if (precondition) {
-			if (precondition.messageRun) return precondition.messageRun(message, command, { ...context, ...this.context });
-			throw new Error(
-				`The precondition "${precondition.name}" is missing a "messageRun" handler, but it was requested for the "${command.name}" command.`
-			);
+			return precondition.messageRun
+				? precondition.messageRun(message, command, { ...context, ...this.context })
+				: precondition.error({
+						identifier: Identifiers.PreconditionMissingMessageHandler,
+						message: `The precondition "${precondition.name}" is missing a "messageRun" handler, but it was requested for the "${command.name}" command.`
+				  });
 		}
-		throw new Error(`The precondition "${this.name}" is not available.`);
+		return Result.err(
+			new UserError({ identifier: Identifiers.PreconditionUnavailable, message: `The precondition "${this.name}" is not available.` })
+		);
 	}
 
 	/**
@@ -94,15 +101,19 @@ export class PreconditionContainerSingle implements IPreconditionContainer {
 	 * @param interaction The interaction that ran this precondition.
 	 * @param command The command the interaction invoked.
 	 */
-	public chatInputRun(interaction: CommandInteraction, command: ChatInputCommand, context: PreconditionContext = {}) {
+	public async chatInputRun(interaction: CommandInteraction, command: ChatInputCommand, context: PreconditionContext = {}) {
 		const precondition = container.stores.get('preconditions').get(this.name);
 		if (precondition) {
-			if (precondition.chatInputRun) return precondition.chatInputRun(interaction, command, { ...context, ...this.context });
-			throw new Error(
-				`The precondition "${precondition.name}" is missing a "chatInputRun" handler, but it was requested for the "${command.name}" command.`
-			);
+			return precondition.chatInputRun
+				? precondition.chatInputRun(interaction, command, { ...context, ...this.context })
+				: precondition.error({
+						identifier: Identifiers.PreconditionMissingChatInputHandler,
+						message: `The precondition "${precondition.name}" is missing a "chatInputRun" handler, but it was requested for the "${command.name}" command.`
+				  });
 		}
-		throw new Error(`The precondition "${this.name}" is not available.`);
+		return Result.err(
+			new UserError({ identifier: Identifiers.PreconditionUnavailable, message: `The precondition "${this.name}" is not available.` })
+		);
 	}
 
 	/**
@@ -111,14 +122,18 @@ export class PreconditionContainerSingle implements IPreconditionContainer {
 	 * @param interaction The interaction that ran this precondition.
 	 * @param command The command the interaction invoked.
 	 */
-	public contextMenuRun(interaction: ContextMenuInteraction, command: ContextMenuCommand, context: PreconditionContext = {}) {
+	public async contextMenuRun(interaction: ContextMenuInteraction, command: ContextMenuCommand, context: PreconditionContext = {}) {
 		const precondition = container.stores.get('preconditions').get(this.name);
 		if (precondition) {
-			if (precondition.contextMenuRun) return precondition.contextMenuRun(interaction, command, { ...context, ...this.context });
-			throw new Error(
-				`The precondition "${precondition.name}" is missing a "contextMenuRun" handler, but it was requested for the "${command.name}" command.`
-			);
+			return precondition.contextMenuRun
+				? precondition.contextMenuRun(interaction, command, { ...context, ...this.context })
+				: precondition.error({
+						identifier: Identifiers.PreconditionMissingContextMenuHandler,
+						message: `The precondition "${precondition.name}" is missing a "contextMenuRun" handler, but it was requested for the "${command.name}" command.`
+				  });
 		}
-		throw new Error(`The precondition "${this.name}" is not available.`);
+		return Result.err(
+			new UserError({ identifier: Identifiers.PreconditionUnavailable, message: `The precondition "${this.name}" is not available.` })
+		);
 	}
 }

--- a/src/lib/utils/preconditions/PreconditionContainerSingle.ts
+++ b/src/lib/utils/preconditions/PreconditionContainerSingle.ts
@@ -80,7 +80,7 @@ export class PreconditionContainerSingle implements IPreconditionContainer {
 	 * @param message The message that ran this precondition.
 	 * @param command The command the message invoked.
 	 */
-	public async messageRun(message: Message, command: MessageCommand, context: PreconditionContext = {}) {
+	public messageRun(message: Message, command: MessageCommand, context: PreconditionContext = {}) {
 		const precondition = container.stores.get('preconditions').get(this.name);
 		if (precondition) {
 			return precondition.messageRun
@@ -101,7 +101,7 @@ export class PreconditionContainerSingle implements IPreconditionContainer {
 	 * @param interaction The interaction that ran this precondition.
 	 * @param command The command the interaction invoked.
 	 */
-	public async chatInputRun(interaction: CommandInteraction, command: ChatInputCommand, context: PreconditionContext = {}) {
+	public chatInputRun(interaction: CommandInteraction, command: ChatInputCommand, context: PreconditionContext = {}) {
 		const precondition = container.stores.get('preconditions').get(this.name);
 		if (precondition) {
 			return precondition.chatInputRun
@@ -122,7 +122,7 @@ export class PreconditionContainerSingle implements IPreconditionContainer {
 	 * @param interaction The interaction that ran this precondition.
 	 * @param command The command the interaction invoked.
 	 */
-	public async contextMenuRun(interaction: ContextMenuInteraction, command: ContextMenuCommand, context: PreconditionContext = {}) {
+	public contextMenuRun(interaction: ContextMenuInteraction, command: ContextMenuCommand, context: PreconditionContext = {}) {
 		const precondition = container.stores.get('preconditions').get(this.name);
 		if (precondition) {
 			return precondition.contextMenuRun

--- a/src/lib/utils/preconditions/PreconditionContainerSingle.ts
+++ b/src/lib/utils/preconditions/PreconditionContainerSingle.ts
@@ -1,5 +1,5 @@
 import { container } from '@sapphire/pieces';
-import { Result } from '@sapphire/result';
+import { err } from '@sapphire/result';
 import type { CommandInteraction, ContextMenuInteraction, Message } from 'discord.js';
 import { Identifiers } from '../../errors/Identifiers';
 import { UserError } from '../../errors/UserError';
@@ -90,9 +90,7 @@ export class PreconditionContainerSingle implements IPreconditionContainer {
 						message: `The precondition "${precondition.name}" is missing a "messageRun" handler, but it was requested for the "${command.name}" command.`
 				  });
 		}
-		return Result.err(
-			new UserError({ identifier: Identifiers.PreconditionUnavailable, message: `The precondition "${this.name}" is not available.` })
-		);
+		return err(new UserError({ identifier: Identifiers.PreconditionUnavailable, message: `The precondition "${this.name}" is not available.` }));
 	}
 
 	/**
@@ -111,9 +109,7 @@ export class PreconditionContainerSingle implements IPreconditionContainer {
 						message: `The precondition "${precondition.name}" is missing a "chatInputRun" handler, but it was requested for the "${command.name}" command.`
 				  });
 		}
-		return Result.err(
-			new UserError({ identifier: Identifiers.PreconditionUnavailable, message: `The precondition "${this.name}" is not available.` })
-		);
+		return err(new UserError({ identifier: Identifiers.PreconditionUnavailable, message: `The precondition "${this.name}" is not available.` }));
 	}
 
 	/**
@@ -132,8 +128,6 @@ export class PreconditionContainerSingle implements IPreconditionContainer {
 						message: `The precondition "${precondition.name}" is missing a "contextMenuRun" handler, but it was requested for the "${command.name}" command.`
 				  });
 		}
-		return Result.err(
-			new UserError({ identifier: Identifiers.PreconditionUnavailable, message: `The precondition "${this.name}" is not available.` })
-		);
+		return err(new UserError({ identifier: Identifiers.PreconditionUnavailable, message: `The precondition "${this.name}" is not available.` }));
 	}
 }


### PR DESCRIPTION
PreconditionContainerSingle doesn't use result, so when command-specific preconditions that don't implement the corresponding run method are ran in [CorePreChatInputCommandRun.ts](https://github.com/sapphiredev/framework/blob/v3.1.1/src/listeners/application-commands/chat-input/CorePreChatInputCommandRun.ts#L20) the `ChatInputCommandDenied` event isn't emitted (similar issue for `CorePreMessageCommandRun.ts` and `CorePreContextMenuCommandRun.ts`). The error propagates upwards and emits a `ListenerError` event instead.

This uses an approach similar to [PreconditionStore.ts](https://github.com/sapphiredev/framework/blob/v3.1.1/src/lib/structures/PreconditionStore.ts#L32-L51) for global preconditions to fix the issue.