### PR TITLE
feat: optionally remove commands that are in the application but not in the commands store

### DIFF
--- a/src/lib/SapphireClient.ts
+++ b/src/lib/SapphireClient.ts
@@ -154,6 +154,13 @@ export interface SapphireClientOptions {
 	 * > ApplicationCommandRegistries: Failed to fetch guild commands for guild \<guild name\> (\<guild id\>). Make sure to authorize your application with the "applications.commands" scope in that guild.
 	 */
 	preventFailedToFetchLogForGuilds?: string[] | true;
+
+	/**
+	 * If set to `true`, it will remove any chat input application commands whose names don't match
+	 * the name of any item in the command store.
+	 * @default false
+	 */
+	automaticallyDeleteUnknownCommands?: boolean;
 }
 
 /**
@@ -305,6 +312,10 @@ export class SapphireClient<Ready extends boolean = boolean> extends Client<Read
 
 		if (options.loadMessageCommandListeners === true) {
 			this.stores.get('listeners').registerPath(join(optionalListenersPath, 'message-command-listeners'));
+		}
+
+		if (options.automaticallyDeleteUnknownCommands === true) {
+			this.stores.get('listeners').registerPath(join(optionalListenersPath, 'unknown-commands'));
 		}
 
 		for (const plugin of SapphireClient.plugins.values(PluginHook.PostInitialization)) {

--- a/src/optional-listeners/unknown-commands/CoreReady.ts
+++ b/src/optional-listeners/unknown-commands/CoreReady.ts
@@ -1,0 +1,19 @@
+import { Listener } from '../../lib/structures/Listener';
+import { Events } from '../../lib/types/Events';
+
+export class CoreEvent extends Listener {
+	public constructor(context: Listener.Context) {
+		super(context, { name: 'CoreReadyUnknownCommand', event: Events.ClientReady, once: true });
+	}
+
+	public async run() {
+		const clientCommands = await this.container.client.application?.commands.fetch();
+		if (!clientCommands) return;
+		const storedCommands = new Set(this.container.stores.get('commands').keys());
+		const commandsToDelete = clientCommands.filter((command) => !storedCommands.has(command.name));
+
+		for (const command of commandsToDelete.values()) {
+			await this.container.client.application?.commands.delete(command);
+		}
+	}
+}

--- a/src/optional-listeners/unknown-commands/CoreReady.ts
+++ b/src/optional-listeners/unknown-commands/CoreReady.ts
@@ -7,10 +7,10 @@ export class CoreEvent extends Listener {
 	}
 
 	public async run() {
-		const clientCommands = await this.container.client.application?.commands.fetch();
-		if (!clientCommands) return;
-		const storedCommands = new Set(this.container.stores.get('commands').keys());
-		const commandsToDelete = clientCommands.filter((command) => !storedCommands.has(command.name));
+		const commands = await this.container.client.application?.commands.fetch();
+		const store = this.container.stores.get('commands');
+		if (!commands) return;
+		const commandsToDelete = commands.filter((command) => !store.has(command.name));
 
 		for (const command of commandsToDelete.values()) {
 			await this.container.client.application?.commands.delete(command);


### PR DESCRIPTION
#557 

- Adds an optional client property `automaticallyDeleteUnknownCommands`.
- When `automaticallyDeleteUnknownCommands` is set to true, it loads an optional listener on the `ready` event that runs once. Gets what application commands are in `client.application.commands` and filters the names that aren't in `container.stores.get('commands').keys()`.

**Before merging:**
- It assumes the command's [internal] name is the same as the piece's name. This should always be correct, right?
- If I understand correctly, it will remove not only chat input commands but also the other kinds. Should this be intended? (I assume yes)
