### PR TITLE
fix(computeDifferences): ensure `Overwrite` strategy is actually faster

### DIFF
--- a/src/lib/types/Enums.ts
+++ b/src/lib/types/Enums.ts
@@ -42,8 +42,6 @@ export enum RegisterBehavior {
 	 *
 	 * @danger This can potentially cause slowdowns when booting up your bot as computing differences on big commands can take a while.
 	 * We recommend you use `OVERWRITE` instead in production.
-	 * @deprecated This mode should be considered "deprecated" in the sense it won't get the same attention as the other modes. It's still usable, but it might
-	 * also remain behind compared to API updates.
 	 */
 	VerboseOverwrite = 'VERBOSE_OVERWRITE'
 }

--- a/src/lib/utils/application-commands/ApplicationCommandRegistry.ts
+++ b/src/lib/utils/application-commands/ApplicationCommandRegistry.ts
@@ -344,7 +344,7 @@ export class ApplicationCommandRegistry {
 			const now = Date.now();
 
 			// Step 0: compute differences
-			differences = getCommandDifferences(convertApplicationCommandToApiData(applicationCommand), apiData, guildId !== null);
+			differences = [...getCommandDifferences(convertApplicationCommandToApiData(applicationCommand), apiData, guildId !== null)];
 
 			const later = Date.now() - now;
 			this.debug(`Took ${later}ms to process differences via computing differences`);

--- a/tests/application-commands/computeDifferences.test.ts
+++ b/tests/application-commands/computeDifferences.test.ts
@@ -1,5 +1,9 @@
 import { ApplicationCommandOptionType, ApplicationCommandType, RESTPostAPIChatInputApplicationCommandsJSONBody } from 'discord-api-types/v10';
-import { getCommandDifferences } from '../../src/lib/utils/application-commands/computeDifferences';
+import { getCommandDifferences as getCommandDifferencesRaw } from '../../src/lib/utils/application-commands/computeDifferences';
+
+function getCommandDifferences(...args: Parameters<typeof getCommandDifferencesRaw>) {
+	return [...getCommandDifferencesRaw(...args)];
+}
 
 describe('Compute differences for provided application commands', () => {
 	test('GIVEN two identical context menu commands THEN do not return any difference', () => {


### PR DESCRIPTION
The way getCommandDifferencesFast was built made sense, returning when the first difference was found.

Only issue is that the method it actually used internally, which is the verbose difference one, would still process all differences in the command BEFORE returning, BEFORE getCommandDifferencesFast would see if any difference is present.

Basically it was faster in name only. Now it should actually be faster 🤞 