### PR TITLE
feat: remove `CommandChatInputRegisterShortcut` alias interface, prefer using `ApplicationCommandRegistry.RegisterOptions` instead

### DIFF
--- a/src/lib/structures/Command.ts
+++ b/src/lib/structures/Command.ts
@@ -1,7 +1,6 @@
 import { ArgumentStream, Lexer, Parser, type IUnorderedStrategy } from '@sapphire/lexure';
 import { AliasPiece, type AliasPieceJSON, type AliasStore } from '@sapphire/pieces';
 import { isNullish, type Awaitable, type NonNullObject } from '@sapphire/utilities';
-import type { LocalizationMap } from 'discord-api-types/v10';
 import {
 	ChatInputCommandInteraction,
 	ContextMenuCommandInteraction,
@@ -12,7 +11,7 @@ import {
 	type Snowflake
 } from 'discord.js';
 import { Args } from '../parsers/Args';
-import { BucketScope, RegisterBehavior } from '../types/Enums';
+import { BucketScope } from '../types/Enums';
 import { acquire } from '../utils/application-commands/ApplicationCommandRegistries';
 import type { ApplicationCommandRegistry } from '../utils/application-commands/ApplicationCommandRegistry';
 import { emitRegistryError } from '../utils/application-commands/emitRegistryError';
@@ -708,13 +707,6 @@ export interface CommandOptions extends AliasPiece.Options, FlagStrategyOptions 
 	 */
 	typing?: boolean;
 }
-
-/**
- * The options for registering a Chat Input Command
- * @see Alias for {@link ApplicationCommandRegistry.RegisterOptions}
- * @deprecated Prefer using {@link ApplicationCommandRegistry.RegisterOptions} instead.
- */
-export type CommandChatInputRegisterShortcut = ApplicationCommandRegistry.RegisterOptions;
 
 export interface MessageCommandContext extends Record<PropertyKey, unknown> {
 	/**

--- a/src/lib/structures/Command.ts
+++ b/src/lib/structures/Command.ts
@@ -709,53 +709,12 @@ export interface CommandOptions extends AliasPiece.Options, FlagStrategyOptions 
 	typing?: boolean;
 }
 
-export interface CommandChatInputRegisterShortcut {
-	/**
-	 * Specifies what we should do when the command is present, but not identical with the data you provided
-	 * @default RegisterBehavior.LogToConsole
-	 */
-	behaviorWhenNotIdentical?: RegisterBehavior;
-	/**
-	 * If we should register the command, be it missing or present already
-	 * @default false
-	 */
-	register: boolean;
-	/**
-	 * If this is specified, the application commands will only be registered for these guild ids.
-	 *
-	 * :::tip
-	 *
-	 * If you want to register both guild and global chat input commands,
-	 * please read the [guide about registering application commands](https://www.sapphirejs.dev/docs/Guide/commands/registering-application-commands) instead.
-	 *
-	 * :::
-	 *
-	 */
-	guildIds?: string[];
-	/**
-	 * Specifies a list of command ids that we should check in the event of a name mismatch
-	 * @default []
-	 */
-	idHints?: string[];
-	/**
-	 * Sets the `defaultPermission` field for the chat input command
-	 *
-	 * :::warn
-	 *
-	 * This will be deprecated in the future for Discord's new permission system.
-	 *
-	 * :::
-	 */
-	defaultPermission?: boolean;
-	/**
-	 * Sets the `nameLocalizations` for the chat input command
-	 */
-	nameLocalizations?: LocalizationMap;
-	/**
-	 * Sets the `descriptionLocalizations` for the chat input command
-	 */
-	descriptionLocalizations?: LocalizationMap;
-}
+/**
+ * The options for registering a Chat Input Command
+ * @see Alias for {@link ApplicationCommandRegistry.RegisterOptions}
+ * @deprecated Prefer using {@link ApplicationCommandRegistry.RegisterOptions} instead.
+ */
+export type CommandChatInputRegisterShortcut = ApplicationCommandRegistry.RegisterOptions;
 
 export interface MessageCommandContext extends Record<PropertyKey, unknown> {
 	/**


### PR DESCRIPTION
The old interface exposed options that were not actually supported
by Sapphire, which was misleading. The whole interface could in fact
be removed as it is was an alias for `ApplicationCommandRegistry.RegisterOptions`.

Arguebly a breaking change for TypeScript users, but because the transition to `ApplicationCommandRegistry.RegisterOptions` is a simple find-and-replace we are pushing this out in a minor version.