### PR TITLE
fix(Command): Do not attempt to execute application command reloading logic when a command does not have any application commands

### DIFF
--- a/src/lib/structures/Command.ts
+++ b/src/lib/structures/Command.ts
@@ -247,6 +247,11 @@ export class Command<PreParseReturn = Args, O extends Command.Options = Command.
 	}
 
 	public override async reload() {
+		// If this command does not have any application commands, just call the super method
+		if (!this.supportsChatInputCommands() && !this.supportsContextMenuCommands()) {
+			return super.reload();
+		}
+
 		// Remove the aliases from the command store
 		const store = this.store as AliasStore<this>;
 		const registry = this.applicationCommandRegistry;

--- a/src/lib/structures/Command.ts
+++ b/src/lib/structures/Command.ts
@@ -299,9 +299,10 @@ export class Command<PreParseReturn = Args, O extends Command.Options = Command.
 			}
 		}
 
+		// If there are no API calls to execute then exit out early
 		if (!updatedRegistry['apiCalls'].length) {
 			return;
-    }
+		}
 
 		// If the default behavior is set to bulk overwrite, handle it as such and return.
 		if (getDefaultBehaviorWhenNotIdentical() === RegisterBehavior.BulkOverwrite) {

--- a/src/lib/structures/Command.ts
+++ b/src/lib/structures/Command.ts
@@ -247,11 +247,6 @@ export class Command<PreParseReturn = Args, O extends Command.Options = Command.
 	}
 
 	public override async reload() {
-		// If this command does not have any application commands, just call the super method
-		if (!this.supportsChatInputCommands() && !this.supportsContextMenuCommands()) {
-			return super.reload();
-		}
-
 		// Remove the aliases from the command store
 		const store = this.store as AliasStore<this>;
 		const registry = this.applicationCommandRegistry;
@@ -296,6 +291,10 @@ export class Command<PreParseReturn = Args, O extends Command.Options = Command.
 				// No point on continuing
 				return;
 			}
+		}
+
+		if (!updatedRegistry['apiCalls'].length) {
+			return;
 		}
 
 		// Re-initialize the store and the API data (insert in the store handles the register method)


### PR DESCRIPTION
Back in v2.5.1 the Command class did not have an overwritten `reload` method at all: https://github.com/sapphiredev/framework/blob/v2.5.1/src/lib/structures/Command.ts

This suggests that we didn't actually need to overwrite the reload method when the command to be reloaded doesn't have any chat input or context menu commands. To this end, after this change, whenever a command is exclusively a message command it will also exclusively call `super.reload()`.