### PR TITLE
fix(Command): support `BulkOverwrite` for reloads

### DIFF
--- a/src/lib/structures/Command.ts
+++ b/src/lib/structures/Command.ts
@@ -12,7 +12,7 @@ import {
 } from 'discord.js';
 import { Args } from '../parsers/Args';
 import { BucketScope, RegisterBehavior } from '../types/Enums';
-import { acquire, defaultBehaviorWhenNotIdentical, handleBulkOverwrite } from '../utils/application-commands/ApplicationCommandRegistries';
+import { acquire, getDefaultBehaviorWhenNotIdentical, handleBulkOverwrite } from '../utils/application-commands/ApplicationCommandRegistries';
 import type { ApplicationCommandRegistry } from '../utils/application-commands/ApplicationCommandRegistry';
 import { emitRegistryError } from '../utils/application-commands/emitRegistryError';
 import { getNeededRegistryParameters } from '../utils/application-commands/getNeededParameters';
@@ -295,7 +295,7 @@ export class Command<PreParseReturn = Args, O extends Command.Options = Command.
 		}
 
 		// If the default behavior is set to bulk overwrite, handle it as such and return.
-		if (defaultBehaviorWhenNotIdentical === RegisterBehavior.BulkOverwrite) {
+		if (getDefaultBehaviorWhenNotIdentical() === RegisterBehavior.BulkOverwrite) {
 			await handleBulkOverwrite(store, this.container.client.application!.commands);
 			return;
 		}

--- a/src/lib/structures/Command.ts
+++ b/src/lib/structures/Command.ts
@@ -294,16 +294,18 @@ export class Command<PreParseReturn = Args, O extends Command.Options = Command.
 			}
 		}
 
+		// If the default behavior is set to bulk overwrite, handle it as such and return.
 		if (defaultBehaviorWhenNotIdentical === RegisterBehavior.BulkOverwrite) {
 			await handleBulkOverwrite(store, this.container.client.application!.commands);
-		} else {
-			// Re-initialize the store and the API data (insert in the store handles the register method)
-			const { applicationCommands, globalCommands, guildCommands } = await getNeededRegistryParameters(updatedRegistry.guildIdsToFetch);
-
-			// Handle the API calls
-			// eslint-disable-next-line @typescript-eslint/dot-notation
-			await updatedRegistry['runAPICalls'](applicationCommands, globalCommands, guildCommands);
+			return;
 		}
+
+		// Re-initialize the store and the API data (insert in the store handles the register method)
+		const { applicationCommands, globalCommands, guildCommands } = await getNeededRegistryParameters(updatedRegistry.guildIdsToFetch);
+
+		// Handle the API calls
+		// eslint-disable-next-line @typescript-eslint/dot-notation
+		await updatedRegistry['runAPICalls'](applicationCommands, globalCommands, guildCommands);
 
 		// Re-set the aliases
 		for (const nameOrId of updatedRegistry.chatInputCommands) {

--- a/src/lib/structures/Command.ts
+++ b/src/lib/structures/Command.ts
@@ -1,5 +1,5 @@
 import { ArgumentStream, Lexer, Parser, type IUnorderedStrategy } from '@sapphire/lexure';
-import { AliasPiece, type AliasPieceJSON, type AliasStore } from '@sapphire/pieces';
+import { AliasPiece, type AliasPieceJSON } from '@sapphire/pieces';
 import { isNullish, type Awaitable, type NonNullObject } from '@sapphire/utilities';
 import {
 	ChatInputCommandInteraction,
@@ -11,13 +11,14 @@ import {
 	type Snowflake
 } from 'discord.js';
 import { Args } from '../parsers/Args';
-import { BucketScope } from '../types/Enums';
-import { acquire } from '../utils/application-commands/ApplicationCommandRegistries';
+import { BucketScope, RegisterBehavior } from '../types/Enums';
+import { acquire, defaultBehaviorWhenNotIdentical, handleBulkOverwrite } from '../utils/application-commands/ApplicationCommandRegistries';
 import type { ApplicationCommandRegistry } from '../utils/application-commands/ApplicationCommandRegistry';
 import { emitRegistryError } from '../utils/application-commands/emitRegistryError';
 import { getNeededRegistryParameters } from '../utils/application-commands/getNeededParameters';
 import { PreconditionContainerArray, type PreconditionEntryResolvable } from '../utils/preconditions/PreconditionContainerArray';
 import { FlagUnorderedStrategy, type FlagStrategyOptions } from '../utils/strategies/FlagUnorderedStrategy';
+import type { CommandStore } from './CommandStore';
 
 export class Command<PreParseReturn = Args, O extends Command.Options = Command.Options> extends AliasPiece<O> {
 	/**
@@ -248,7 +249,7 @@ export class Command<PreParseReturn = Args, O extends Command.Options = Command.
 
 	public override async reload() {
 		// Remove the aliases from the command store
-		const store = this.store as AliasStore<this>;
+		const store = this.store as CommandStore;
 		const registry = this.applicationCommandRegistry;
 
 		for (const nameOrId of registry.chatInputCommands) {
@@ -293,12 +294,16 @@ export class Command<PreParseReturn = Args, O extends Command.Options = Command.
 			}
 		}
 
-		// Re-initialize the store and the API data (insert in the store handles the register method)
-		const { applicationCommands, globalCommands, guildCommands } = await getNeededRegistryParameters(updatedRegistry.guildIdsToFetch);
+		if (defaultBehaviorWhenNotIdentical === RegisterBehavior.BulkOverwrite) {
+			await handleBulkOverwrite(store, this.container.client.application!.commands);
+		} else {
+			// Re-initialize the store and the API data (insert in the store handles the register method)
+			const { applicationCommands, globalCommands, guildCommands } = await getNeededRegistryParameters(updatedRegistry.guildIdsToFetch);
 
-		// Handle the API calls
-		// eslint-disable-next-line @typescript-eslint/dot-notation
-		await updatedRegistry['runAPICalls'](applicationCommands, globalCommands, guildCommands);
+			// Handle the API calls
+			// eslint-disable-next-line @typescript-eslint/dot-notation
+			await updatedRegistry['runAPICalls'](applicationCommands, globalCommands, guildCommands);
+		}
 
 		// Re-set the aliases
 		for (const nameOrId of updatedRegistry.chatInputCommands) {

--- a/src/lib/structures/CommandStore.ts
+++ b/src/lib/structures/CommandStore.ts
@@ -70,25 +70,17 @@ export class CommandStore extends AliasStore<Command> {
 			}
 		}
 
-		type BaseGetNeededRegistryParameters = Awaited<ReturnType<typeof getNeededRegistryParameters>>;
-		let applicationCommands: BaseGetNeededRegistryParameters['applicationCommands'] | null = null;
-		let globalCommands: BaseGetNeededRegistryParameters['globalCommands'] | null = null;
-		let guildCommands: BaseGetNeededRegistryParameters['guildCommands'] | null = null;
-
+		// If the default behavior is set to bulk overwrite, handle it as such and return.
 		if (defaultBehaviorWhenNotIdentical === RegisterBehavior.BulkOverwrite) {
 			await handleBulkOverwrite(this, this.container.client.application.commands);
-		} else {
-			const neededRegistryParameters = await getNeededRegistryParameters(allGuildIdsToFetchCommandsFor);
-			applicationCommands = neededRegistryParameters.applicationCommands;
-			globalCommands = neededRegistryParameters.globalCommands;
-			guildCommands = neededRegistryParameters.guildCommands;
+			return;
 		}
 
+		const { applicationCommands, globalCommands, guildCommands } = await getNeededRegistryParameters(allGuildIdsToFetchCommandsFor);
+
 		for (const command of this.values()) {
-			if (applicationCommands && globalCommands && guildCommands) {
-				// eslint-disable-next-line @typescript-eslint/dot-notation
-				await command.applicationCommandRegistry['runAPICalls'](applicationCommands, globalCommands, guildCommands);
-			}
+			// eslint-disable-next-line @typescript-eslint/dot-notation
+			await command.applicationCommandRegistry['runAPICalls'](applicationCommands, globalCommands, guildCommands);
 
 			// Reinitialize the aliases
 			for (const nameOrId of command.applicationCommandRegistry.chatInputCommands) {

--- a/src/lib/structures/CommandStore.ts
+++ b/src/lib/structures/CommandStore.ts
@@ -2,7 +2,7 @@ import { AliasStore } from '@sapphire/pieces';
 import { RegisterBehavior } from '../types/Enums';
 import {
 	allGuildIdsToFetchCommandsFor,
-	defaultBehaviorWhenNotIdentical,
+	getDefaultBehaviorWhenNotIdentical,
 	handleBulkOverwrite,
 	registries
 } from '../utils/application-commands/ApplicationCommandRegistries';
@@ -71,7 +71,7 @@ export class CommandStore extends AliasStore<Command> {
 		}
 
 		// If the default behavior is set to bulk overwrite, handle it as such and return.
-		if (defaultBehaviorWhenNotIdentical === RegisterBehavior.BulkOverwrite) {
+		if (getDefaultBehaviorWhenNotIdentical() === RegisterBehavior.BulkOverwrite) {
 			await handleBulkOverwrite(this, this.container.client.application.commands);
 			return;
 		}

--- a/src/lib/utils/application-commands/ApplicationCommandRegistries.ts
+++ b/src/lib/utils/application-commands/ApplicationCommandRegistries.ts
@@ -69,7 +69,7 @@ export async function handleRegistryAPICalls() {
 	await handleAppendOrUpdate(commandStore, params);
 }
 
-async function handleBulkOverwrite(commandStore: CommandStore, applicationCommands: ApplicationCommandManager) {
+export async function handleBulkOverwrite(commandStore: CommandStore, applicationCommands: ApplicationCommandManager) {
 	// Map registries by guild, global, etc
 	const foundGlobalCommands: BulkOverwriteData[] = [];
 	const foundGuildCommands: Record<string, BulkOverwriteData[]> = {};

--- a/src/lib/utils/application-commands/ApplicationCommandRegistries.ts
+++ b/src/lib/utils/application-commands/ApplicationCommandRegistries.ts
@@ -109,7 +109,7 @@ export async function handleBulkOverwrite(commandStore: CommandStore, applicatio
 				registry.globalCommandId = id;
 				registry.addChatInputCommandIds(id);
 
-				// idHints are useless, and any manually added id or names could end up not being valid anymore if you use bulk overwrites
+				// idHints are useless, and any manually added id or names could end up not being valid any longer if you use bulk overwrites
 				// That said, this might be an issue, so we might need to do it like `handleAppendOrUpdate`
 				commandStore.aliases.set(id, piece);
 			} else {


### PR DESCRIPTION
This ensures that when `RegisterBehavior.BulkOverwrite` is set, the command does not attempt to register individually which would always cause issues.

resolves #599 