### PR TITLE
fix(Args): ensure proper error types are always thrown

### DIFF
--- a/src/lib/parsers/Args.ts
+++ b/src/lib/parsers/Args.ts
@@ -172,7 +172,7 @@ export class Args {
 	public async pick<K extends keyof ArgType>(type: K, options?: ArgOptions): Promise<ArgType[K]>;
 	public async pick<K extends keyof ArgType>(type: K, options?: ArgOptions): Promise<ArgType[K]> {
 		const result = await this.pickResult(type, options);
-		return result.unwrap();
+		return result.unwrapRaw();
 	}
 
 	/**
@@ -259,7 +259,7 @@ export class Args {
 	public async rest<K extends keyof ArgType>(type: K, options?: ArgOptions): Promise<ArgType[K]>;
 	public async rest<K extends keyof ArgType>(type: K, options?: ArgOptions): Promise<ArgType[K]> {
 		const result = await this.restResult(type, options);
-		return result.unwrap();
+		return result.unwrapRaw();
 	}
 
 	/**
@@ -299,6 +299,7 @@ export class Args {
 		if (this.parser.finished) return this.missingArguments();
 
 		const output: ArgType[K][] = [];
+
 		for (let i = 0, times = options.times ?? Infinity; i < times; i++) {
 			const result = await this.parser.singleParseAsync(async (arg) =>
 				argument.run(arg, {
@@ -310,6 +311,7 @@ export class Args {
 					...options
 				})
 			);
+
 			if (result.isErr()) {
 				const error = result.unwrapErr();
 				if (error === null) break;
@@ -356,7 +358,7 @@ export class Args {
 	public async repeat<K extends keyof ArgType>(type: K, options?: RepeatArgOptions): Promise<ArgType[K][]>;
 	public async repeat<K extends keyof ArgType>(type: K, options?: RepeatArgOptions): Promise<ArgType[K][]> {
 		const result = await this.repeatResult(type, options);
-		return result.unwrap();
+		return result.unwrapRaw();
 	}
 
 	/**
@@ -508,7 +510,7 @@ export class Args {
 	public async peek<K extends keyof ArgType>(type: (() => Argument.Result<ArgType[K]>) | K, options?: ArgOptions): Promise<ArgType[K]>;
 	public async peek<K extends keyof ArgType>(type: (() => Argument.Result<ArgType[K]>) | K, options?: ArgOptions): Promise<ArgType[K]> {
 		const result = await this.peekResult(type, options);
-		return result.unwrap();
+		return result.unwrapRaw();
 	}
 
 	/**


### PR DESCRIPTION
This changes the `result.unwrap()` calls to `result.unwrapRaw()` to ensure that the erorr that gets thrown for the following methods:
- `args.pick(...)`
- `args.rest(...)`
- `args.repeat(...)`
- `args.peek(...)` This makes it so that the error that ends up in `messageCommandError` listener will have the proper error type. Furthermore, it can also be handled properly when chaining `.catch()` calls to the `args.X` method.

resolves #528


---

Reproduced the error first with https://github.com/favna/musical-giggle, then confirmed the fix using a debugger with the code from the issue. Also confirmed that it is resolved for `Args.make` by copying the code from https://github.com/favna/repro-sapphire-unwrap-error which was created for a separately reported issue.