### PR TITLE
fix: use `declare` for store properties to avoid the need for `as *Store`

### DIFF
--- a/src/lib/structures/Argument.ts
+++ b/src/lib/structures/Argument.ts
@@ -4,6 +4,7 @@ import type { Awaitable } from '@sapphire/utilities';
 import type { Message } from 'discord.js';
 import type { ArgumentError } from '../errors/ArgumentError';
 import { Args } from '../parsers/Args';
+import type { ArgumentStore } from './ArgumentStore';
 import type { MessageCommand } from './Command';
 
 /**
@@ -102,6 +103,11 @@ export interface IArgument<T> {
  * ```
  */
 export abstract class Argument<T = unknown, O extends Argument.Options = Argument.Options> extends AliasPiece<O> implements IArgument<T> {
+	/**
+	 * The {@link ArgumentStore} that contains this {@link Argument}.
+	 */
+	public declare store: ArgumentStore;
+
 	public abstract run(parameter: string, context: Argument.Context<T>): Argument.AwaitableResult<T>;
 
 	/**

--- a/src/lib/structures/Command.ts
+++ b/src/lib/structures/Command.ts
@@ -22,6 +22,11 @@ import type { CommandStore } from './CommandStore';
 
 export class Command<PreParseReturn = Args, O extends Command.Options = Command.Options> extends AliasPiece<O> {
 	/**
+	 * The {@link CommandStore} that contains this {@link Command}.
+	 */
+	public declare store: CommandStore;
+
+	/**
 	 * A basic summary about the command
 	 * @since 1.0.0
 	 */
@@ -249,7 +254,7 @@ export class Command<PreParseReturn = Args, O extends Command.Options = Command.
 
 	public override async reload() {
 		// Remove the aliases from the command store
-		const store = this.store as CommandStore;
+		const { store } = this;
 		const registry = this.applicationCommandRegistry;
 
 		for (const nameOrId of registry.chatInputCommands) {

--- a/src/lib/structures/InteractionHandler.ts
+++ b/src/lib/structures/InteractionHandler.ts
@@ -2,8 +2,14 @@ import { Piece } from '@sapphire/pieces';
 import { Option } from '@sapphire/result';
 import type { Awaitable } from '@sapphire/utilities';
 import type { Interaction } from 'discord.js';
+import type { InteractionHandlerStore } from './InteractionHandlerStore';
 
 export abstract class InteractionHandler<O extends InteractionHandler.Options = InteractionHandler.Options> extends Piece<O> {
+	/**
+	 * The {@link InteractionHandlerStore} that contains this {@link InteractionHandler}.
+	 */
+	public declare store: InteractionHandlerStore;
+
 	/**
 	 * The type for this handler
 	 * @since 3.0.0

--- a/src/lib/structures/Listener.ts
+++ b/src/lib/structures/Listener.ts
@@ -3,6 +3,7 @@ import { Result } from '@sapphire/result';
 import type { Client, ClientEvents } from 'discord.js';
 import type { EventEmitter } from 'node:events';
 import { Events } from '../types/Events';
+import type { ListenerStore } from './ListenerStore';
 
 /**
  * The base event class. This class is abstract and is to be extended by subclasses, which should implement the methods. In
@@ -44,6 +45,11 @@ import { Events } from '../types/Events';
  * ```
  */
 export abstract class Listener<E extends keyof ClientEvents | symbol = '', O extends Listener.Options = Listener.Options> extends Piece<O> {
+	/**
+	 * The {@link ListenerStore} that contains this {@link Listener}.
+	 */
+	public declare store: ListenerStore;
+
 	/**
 	 * The emitter, if any.
 	 * @since 2.0.0

--- a/src/lib/structures/Precondition.ts
+++ b/src/lib/structures/Precondition.ts
@@ -13,11 +13,17 @@ import type { CooldownPreconditionContext } from '../../preconditions/Cooldown';
 import { PreconditionError } from '../errors/PreconditionError';
 import type { UserError } from '../errors/UserError';
 import type { ChatInputCommand, ContextMenuCommand, MessageCommand } from './Command';
+import type { PreconditionStore } from './PreconditionStore';
 
 export type PreconditionResult = Awaitable<Result<unknown, UserError>>;
 export type AsyncPreconditionResult = Promise<Result<unknown, UserError>>;
 
 export class Precondition<O extends Precondition.Options = Precondition.Options> extends Piece<O> {
+	/**
+	 * The {@link PreconditionStore} that contains this {@link Precondition}.
+	 */
+	public declare store: PreconditionStore;
+
 	public readonly position: number | null;
 
 	public constructor(context: Piece.Context, options: Precondition.Options = {}) {


### PR DESCRIPTION
This ensures that people no longed need to write code such as `const commandsStore = this.store as CommandStore` but instead can keep out the typecast.

resolves #382