### PR TITLE
refactor: expose argument context types

### DIFF
--- a/src/arguments/CoreBoolean.ts
+++ b/src/arguments/CoreBoolean.ts
@@ -1,13 +1,14 @@
 import type { PieceContext } from '@sapphire/pieces';
 import { resolveBoolean } from '../lib/resolvers/boolean';
 import { Argument } from '../lib/structures/Argument';
+import type { BooleanArgumentContext } from '../lib/types/ArgumentContexts';
 
 export class CoreArgument extends Argument<boolean> {
 	public constructor(context: PieceContext) {
 		super(context, { name: 'boolean' });
 	}
 
-	public run(parameter: string, context: { readonly truths?: string[]; falses?: readonly string[] } & Argument.Context): Argument.Result<boolean> {
+	public run(parameter: string, context: BooleanArgumentContext): Argument.Result<boolean> {
 		const resolved = resolveBoolean(parameter, { truths: context.truths, falses: context.falses });
 		return resolved.mapErrInto((identifier) =>
 			this.error({

--- a/src/arguments/CoreEnum.ts
+++ b/src/arguments/CoreEnum.ts
@@ -1,16 +1,14 @@
 import type { PieceContext } from '@sapphire/pieces';
 import { resolveEnum } from '../lib/resolvers/enum';
 import { Argument } from '../lib/structures/Argument';
+import type { EnumArgumentContext } from '../lib/types/ArgumentContexts';
 
 export class CoreArgument extends Argument<string> {
 	public constructor(context: PieceContext) {
 		super(context, { name: 'enum' });
 	}
 
-	public run(
-		parameter: string,
-		context: { readonly enum?: string[]; readonly caseInsensitive?: boolean } & Argument.Context
-	): Argument.Result<string> {
+	public run(parameter: string, context: EnumArgumentContext): Argument.Result<string> {
 		const resolved = resolveEnum(parameter, { enum: context.enum, caseInsensitive: context.caseInsensitive });
 		return resolved.mapErrInto((identifier) =>
 			this.error({

--- a/src/arguments/CoreMessage.ts
+++ b/src/arguments/CoreMessage.ts
@@ -1,17 +1,15 @@
 import type { PieceContext } from '@sapphire/pieces';
 import type { Message } from 'discord.js';
-import { resolveMessage, type MessageResolverOptions } from '../lib/resolvers/message';
+import { resolveMessage } from '../lib/resolvers/message';
 import { Argument } from '../lib/structures/Argument';
+import type { MessageArgumentContext } from '../lib/types/ArgumentContexts';
 
 export class CoreArgument extends Argument<Message> {
 	public constructor(context: PieceContext) {
 		super(context, { name: 'message' });
 	}
 
-	public async run(
-		parameter: string,
-		context: Omit<MessageResolverOptions, 'messageOrInteraction'> & Argument.Context
-	): Argument.AsyncResult<Message> {
+	public async run(parameter: string, context: MessageArgumentContext): Argument.AsyncResult<Message> {
 		const channel = context.channel ?? context.message.channel;
 		const resolved = await resolveMessage(parameter, {
 			messageOrInteraction: context.message,

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,6 +68,7 @@ export * from './lib/structures/Listener';
 export * from './lib/structures/ListenerStore';
 export * from './lib/structures/Precondition';
 export * from './lib/structures/PreconditionStore';
+export * from './lib/types/ArgumentContexts';
 export * from './lib/types/Enums';
 export * from './lib/types/Events';
 export {

--- a/src/lib/types/ArgumentContexts.ts
+++ b/src/lib/types/ArgumentContexts.ts
@@ -1,0 +1,40 @@
+import type { MessageResolverOptions } from '../resolvers/message';
+import type { Argument } from '../structures/Argument';
+
+/**
+ * The context for the `'enum'` argument.
+ * @since 4.2.0 (🌿)
+ */
+export interface EnumArgumentContext extends Argument.Context {
+	readonly enum?: string[];
+	readonly caseInsensitive?: boolean;
+}
+
+/**
+ * The context for the `'boolean'` argument.
+ * @since 4.2.0 (🌿)
+ */
+export interface BooleanArgumentContext extends Argument.Context {
+	/**
+	 * The words that resolve to `true`.
+	 * Any words added to this array will be merged with the words:
+	 * ```ts
+	 * ['1', 'true', '+', 't', 'yes', 'y']
+	 * ```
+	 */
+	readonly truths?: string[];
+	/**
+	 * The words that resolve to `false`.
+	 * Any words added to this array will be merged with the words:
+	 * ```ts
+	 * ['0', 'false', '-', 'f', 'no', 'n']
+	 * ```
+	 */
+	readonly falses?: string[];
+}
+
+/**
+ * The context for the `'message'` argument.
+ * @since 4.2.0 (🌿)
+ */
+export type MessageArgumentContext = Omit<MessageResolverOptions, 'messageOrInteraction'> & Argument.Context;


### PR DESCRIPTION
This will expose the argument context types to the end-users for easier typing.

Version since listed as 4.2.0 because this is to be released alongside #611 which is a https://github.com/sapphiredev/framework/labels/semver%3Aminor