### PR TITLE
feat: make the Application Command Registries status listeners optional

### DIFF
--- a/src/lib/SapphireClient.ts
+++ b/src/lib/SapphireClient.ts
@@ -107,6 +107,14 @@ export interface SapphireClientOptions {
 	enableLoaderTraceLoggings?: boolean;
 
 	/**
+	 * If Sapphire should load the pre-included application command registries status listeners that log the status of registering application commands to the {@link SapphireClient.logger} instance.
+	 * This includes the events {@link Events.ApplicationCommandRegistriesInitialising} and {@link Events.ApplicationCommandRegistriesRegistered}.
+	 * @since 4.4.0
+	 * @default true
+	 */
+	loadApplicationCommandRegistriesStatusListeners?: boolean;
+
+	/**
 	 * If Sapphire should load the pre-included error event listeners that log any encountered errors to the {@link SapphireClient.logger} instance
 	 * @since 1.0.0
 	 * @default true
@@ -298,6 +306,10 @@ export class SapphireClient<Ready extends boolean = boolean> extends Client<Read
 			.register(new PreconditionStore().registerPath(join(__dirname, '..', 'preconditions')));
 
 		const optionalListenersPath = join(__dirname, '..', 'optional-listeners');
+
+		if (options.loadApplicationCommandRegistriesStatusListeners !== false) {
+			this.stores.get('listeners').registerPath(join(optionalListenersPath, 'application-command-registries-listeners'));
+		}
 
 		if (options.loadDefaultErrorListeners !== false) {
 			this.stores.get('listeners').registerPath(join(optionalListenersPath, 'error-listeners'));

--- a/src/lib/types/Events.ts
+++ b/src/lib/types/Events.ts
@@ -206,6 +206,11 @@ export const Events = {
 	CommandApplicationCommandRegistryError: 'commandApplicationCommandRegistryError' as const,
 
 	/**
+	 * Emitted when the application command registries are being initialized.
+	 */
+	ApplicationCommandRegistriesInitialising: 'applicationCommandRegistriesInitialising' as const,
+
+	/**
 	 * Emitted once the application command registries have been initialized.
 	 * @param {Map<string, ApplicationCommandRegistry>} registries The initialised registries
 	 */
@@ -566,7 +571,8 @@ declare module 'discord.js' {
 
 		[SapphireEvents.ListenerError]: [error: unknown, payload: ListenerErrorPayload];
 		[SapphireEvents.CommandApplicationCommandRegistryError]: [error: unknown, command: Command];
-		[SapphireEvents.ApplicationCommandRegistriesRegistered]: [registries: Map<string, ApplicationCommandRegistry>];
+		[SapphireEvents.ApplicationCommandRegistriesInitialising]: [message: string];
+		[SapphireEvents.ApplicationCommandRegistriesRegistered]: [registries: Map<string, ApplicationCommandRegistry>, timeTaken?: number];
 		[SapphireEvents.ApplicationCommandRegistriesBulkOverwriteError]: [error: unknown, guildId: string | null];
 
 		[SapphireEvents.PreMessageParsed]: [message: Message];

--- a/src/lib/types/Events.ts
+++ b/src/lib/types/Events.ts
@@ -572,7 +572,7 @@ declare module 'discord.js' {
 		[SapphireEvents.ListenerError]: [error: unknown, payload: ListenerErrorPayload];
 		[SapphireEvents.CommandApplicationCommandRegistryError]: [error: unknown, command: Command];
 		[SapphireEvents.ApplicationCommandRegistriesInitialising]: [];
-		[SapphireEvents.ApplicationCommandRegistriesRegistered]: [registries: Map<string, ApplicationCommandRegistry>, timeTaken?: number];
+		[SapphireEvents.ApplicationCommandRegistriesRegistered]: [registries: Map<string, ApplicationCommandRegistry>, timeTaken: number];
 		[SapphireEvents.ApplicationCommandRegistriesBulkOverwriteError]: [error: unknown, guildId: string | null];
 
 		[SapphireEvents.PreMessageParsed]: [message: Message];

--- a/src/lib/types/Events.ts
+++ b/src/lib/types/Events.ts
@@ -571,7 +571,7 @@ declare module 'discord.js' {
 
 		[SapphireEvents.ListenerError]: [error: unknown, payload: ListenerErrorPayload];
 		[SapphireEvents.CommandApplicationCommandRegistryError]: [error: unknown, command: Command];
-		[SapphireEvents.ApplicationCommandRegistriesInitialising]: [message: string];
+		[SapphireEvents.ApplicationCommandRegistriesInitialising]: [];
 		[SapphireEvents.ApplicationCommandRegistriesRegistered]: [registries: Map<string, ApplicationCommandRegistry>, timeTaken?: number];
 		[SapphireEvents.ApplicationCommandRegistriesBulkOverwriteError]: [error: unknown, guildId: string | null];
 

--- a/src/lib/utils/application-commands/ApplicationCommandRegistries.ts
+++ b/src/lib/utils/application-commands/ApplicationCommandRegistries.ts
@@ -47,6 +47,8 @@ export function getDefaultBehaviorWhenNotIdentical() {
 }
 
 export async function handleRegistryAPICalls() {
+	container.client.emit(Events.ApplicationCommandRegistriesInitialising, `ApplicationCommandRegistries: Initializing...`);
+
 	const commandStore = container.stores.get('commands');
 
 	for (const command of commandStore.values()) {
@@ -171,6 +173,8 @@ async function handleAppendOrUpdate(
 	commandStore: CommandStore,
 	{ applicationCommands, globalCommands, guildCommands }: Awaited<ReturnType<typeof getNeededRegistryParameters>>
 ) {
+	const now = Date.now();
+
 	for (const registry of registries.values()) {
 		// eslint-disable-next-line @typescript-eslint/dot-notation
 		await registry['runAPICalls'](applicationCommands, globalCommands, guildCommands);
@@ -188,7 +192,7 @@ async function handleAppendOrUpdate(
 		}
 	}
 
-	container.client.emit(Events.ApplicationCommandRegistriesRegistered, registries);
+	container.client.emit(Events.ApplicationCommandRegistriesRegistered, registries, Date.now() - now);
 }
 
 interface BulkOverwriteData {

--- a/src/lib/utils/application-commands/ApplicationCommandRegistries.ts
+++ b/src/lib/utils/application-commands/ApplicationCommandRegistries.ts
@@ -47,7 +47,7 @@ export function getDefaultBehaviorWhenNotIdentical() {
 }
 
 export async function handleRegistryAPICalls() {
-	container.client.emit(Events.ApplicationCommandRegistriesInitialising, `ApplicationCommandRegistries: Initializing...`);
+	container.client.emit(Events.ApplicationCommandRegistriesInitialising);
 
 	const commandStore = container.stores.get('commands');
 
@@ -72,6 +72,8 @@ export async function handleRegistryAPICalls() {
 }
 
 export async function handleBulkOverwrite(commandStore: CommandStore, applicationCommands: ApplicationCommandManager) {
+	const now = Date.now();
+
 	// Map registries by guild, global, etc
 	const foundGlobalCommands: BulkOverwriteData[] = [];
 	const foundGuildCommands: Record<string, BulkOverwriteData[]> = {};
@@ -166,7 +168,7 @@ export async function handleBulkOverwrite(commandStore: CommandStore, applicatio
 		}
 	}
 
-	container.client.emit(Events.ApplicationCommandRegistriesRegistered, registries);
+	container.client.emit(Events.ApplicationCommandRegistriesRegistered, registries, Date.now() - now);
 }
 
 async function handleAppendOrUpdate(

--- a/src/listeners/CoreReady.ts
+++ b/src/listeners/CoreReady.ts
@@ -10,12 +10,6 @@ export class CoreEvent extends Listener {
 	public async run() {
 		this.container.client.id ??= this.container.client.user?.id ?? null;
 
-		this.container.logger.info(`ApplicationCommandRegistries: Initializing...`);
-
-		const now = Date.now();
 		await handleRegistryAPICalls();
-		const diff = Date.now() - now;
-
-		this.container.logger.info(`ApplicationCommandRegistries: Took ${diff.toLocaleString()}ms to initialize.`);
 	}
 }

--- a/src/optional-listeners/application-command-registries-listeners/CoreApplicationCommandRegistriesInitialising.ts
+++ b/src/optional-listeners/application-command-registries-listeners/CoreApplicationCommandRegistriesInitialising.ts
@@ -1,0 +1,12 @@
+import { Listener } from '../../lib/structures/Listener';
+import { Events } from '../../lib/types/Events';
+
+export class CoreEvent extends Listener<typeof Events.ApplicationCommandRegistriesInitialising> {
+	public constructor(context: Listener.Context) {
+		super(context, { event: Events.ApplicationCommandRegistriesInitialising, once: true });
+	}
+
+	public run(message: string) {
+		this.container.logger.info(message);
+	}
+}

--- a/src/optional-listeners/application-command-registries-listeners/CoreApplicationCommandRegistriesInitialising.ts
+++ b/src/optional-listeners/application-command-registries-listeners/CoreApplicationCommandRegistriesInitialising.ts
@@ -6,7 +6,7 @@ export class CoreEvent extends Listener<typeof Events.ApplicationCommandRegistri
 		super(context, { event: Events.ApplicationCommandRegistriesInitialising, once: true });
 	}
 
-	public run(message: string) {
-		this.container.logger.info(message);
+	public run() {
+		this.container.logger.info('ApplicationCommandRegistries: Initializing...');
 	}
 }

--- a/src/optional-listeners/application-command-registries-listeners/CoreApplicationCommandRegistriesRegistered.ts
+++ b/src/optional-listeners/application-command-registries-listeners/CoreApplicationCommandRegistriesRegistered.ts
@@ -1,0 +1,13 @@
+import { Listener } from '../../lib/structures/Listener';
+import { Events } from '../../lib/types/Events';
+import type { ApplicationCommandRegistry } from '../../lib/utils/application-commands/ApplicationCommandRegistry';
+
+export class CoreEvent extends Listener<typeof Events.ApplicationCommandRegistriesRegistered> {
+	public constructor(context: Listener.Context) {
+		super(context, { event: Events.ApplicationCommandRegistriesRegistered, once: true });
+	}
+
+	public run(_registries: Map<string, ApplicationCommandRegistry>, timeTaken: number) {
+		this.container.logger.info(`ApplicationCommandRegistries: Took ${timeTaken.toLocaleString()}ms to initialize.`);
+	}
+}


### PR DESCRIPTION
ref: [on ready message - forum post](https://discord.com/channels/737141877803057244/1095353945150468166)

---

This PR addresses a few things:
1. It makes the 2 logs for registering application commands optional by setting the new client option `loadApplicationCommandRegistriesStatusListeners`
2. `Events.ApplicationCommandRegistriesRegistered` can now accept an (optional) `timeTaken` parameter
3. The message `ApplicationCommandRegistries: Initializing...` has been moved from `CoreReady` to `handleRegistryAPICalls` and is emitted to the new event `Events.ApplicationCommandRegistriesInitialising`
4. A core event for `Events.ApplicationCommandRegistriesRegistered` was added that logs the `ApplicationCommandRegistries: Took ${diff.toLocaleString()}ms to initialize.)` message