### PR TITLE
refactor(preconditions): add `RunIn`, deprecate everything else

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import { CorePrecondition as GuildTextOnly } from './preconditions/GuildTextOnly
 import { CorePrecondition as GuildThreadOnly } from './preconditions/GuildThreadOnly';
 import { CorePrecondition as GuildVoiceOnly } from './preconditions/GuildVoiceOnly';
 import { CorePrecondition as NSFW } from './preconditions/NSFW';
+import { CorePrecondition as RunIn } from './preconditions/RunIn';
 import { CorePrecondition as UserPermissions } from './preconditions/UserPermissions';
 
 const ApplicationCommandRegistries = {
@@ -32,12 +33,12 @@ const ApplicationCommandRegistries = {
 export {
 	AliasPiece,
 	AliasStore,
-	container,
 	LoaderError,
 	MissingExportsError,
 	Piece,
 	Store,
 	StoreRegistry,
+	container,
 	type AliasPieceOptions,
 	type PieceContext,
 	type PieceOptions,
@@ -46,6 +47,7 @@ export {
 } from '@sapphire/pieces';
 export * from '@sapphire/result';
 export type { Awaitable } from '@sapphire/utilities';
+export * from './lib/SapphireClient';
 export * from './lib/errors/ArgumentError';
 export * from './lib/errors/Identifiers';
 export * from './lib/errors/PreconditionError';
@@ -57,7 +59,6 @@ export * from './lib/plugins/symbols';
 export type { EmojiObject } from './lib/resolvers/emoji';
 export * as Resolvers from './lib/resolvers/index';
 export type { MessageResolverOptions } from './lib/resolvers/message';
-export * from './lib/SapphireClient';
 export * from './lib/structures/Argument';
 export * from './lib/structures/ArgumentStore';
 export * from './lib/structures/Command';
@@ -77,32 +78,44 @@ export {
 } from './lib/utils/application-commands/ApplicationCommandRegistry';
 export * from './lib/utils/logger/ILogger';
 export * from './lib/utils/logger/Logger';
+export * from './lib/utils/preconditions/IPreconditionContainer';
+export * from './lib/utils/preconditions/PreconditionContainerArray';
+export * from './lib/utils/preconditions/PreconditionContainerSingle';
 export * from './lib/utils/preconditions/conditions/IPreconditionCondition';
 export * from './lib/utils/preconditions/conditions/PreconditionConditionAnd';
 export * from './lib/utils/preconditions/conditions/PreconditionConditionOr';
 export * from './lib/utils/preconditions/containers/ClientPermissionsPrecondition';
 export * from './lib/utils/preconditions/containers/UserPermissionsPrecondition';
-export * from './lib/utils/preconditions/IPreconditionContainer';
-export * from './lib/utils/preconditions/PreconditionContainerArray';
-export * from './lib/utils/preconditions/PreconditionContainerSingle';
 export { ApplicationCommandRegistries };
 
+/* eslint-disable deprecation/deprecation */
 export const CorePreconditions = {
 	ClientPermissions,
 	Cooldown,
+	/** @deprecated Use {@link RunIn} instead. */
 	DMOnly,
 	Enabled,
+	RunIn,
+	/** @deprecated Use {@link RunIn} instead. */
 	GuildNewsOnly,
+	/** @deprecated Use {@link RunIn} instead. */
 	GuildNewsThreadOnly,
+	/** @deprecated Use {@link RunIn} instead. */
 	GuildOnly,
+	/** @deprecated Use {@link RunIn} instead. */
 	GuildPrivateThreadOnly,
+	/** @deprecated Use {@link RunIn} instead. */
 	GuildPublicThreadOnly,
+	/** @deprecated Use {@link RunIn} instead. */
 	GuildTextOnly,
+	/** @deprecated Use {@link RunIn} instead. */
 	GuildVoiceOnly,
+	/** @deprecated Use {@link RunIn} instead. */
 	GuildThreadOnly,
 	NSFW,
 	UserPermissions
 };
+/* eslint-enable deprecation/deprecation */
 
 export namespace CorePreconditions {
 	export type UserPermissionsPreconditionContext = PermissionPreconditionContext;

--- a/src/lib/errors/Identifiers.ts
+++ b/src/lib/errors/Identifiers.ts
@@ -45,20 +45,30 @@ export enum Identifiers {
 	CommandDisabled = 'commandDisabled',
 
 	PreconditionCooldown = 'preconditionCooldown',
+	/** @deprecated Use {@link PreconditionRunIn} instead. */
 	PreconditionDMOnly = 'preconditionDmOnly',
+	/** @deprecated Use {@link PreconditionRunIn} instead. */
 	PreconditionGuildNewsOnly = 'preconditionGuildNewsOnly',
+	/** @deprecated Use {@link PreconditionRunIn} instead. */
 	PreconditionGuildNewsThreadOnly = 'preconditionGuildNewsThreadOnly',
+	/** @deprecated Use {@link PreconditionRunIn} instead. */
 	PreconditionGuildOnly = 'preconditionGuildOnly',
+	/** @deprecated Use {@link PreconditionRunIn} instead. */
 	PreconditionGuildPrivateThreadOnly = 'preconditionGuildPrivateThreadOnly',
+	/** @deprecated Use {@link PreconditionRunIn} instead. */
 	PreconditionGuildPublicThreadOnly = 'preconditionGuildPublicThreadOnly',
+	/** @deprecated Use {@link PreconditionRunIn} instead. */
 	PreconditionGuildTextOnly = 'preconditionGuildTextOnly',
+	/** @deprecated Use {@link PreconditionRunIn} instead. */
 	PreconditionGuildVoiceOnly = 'preconditionGuildVoiceOnly',
 	PreconditionNSFW = 'preconditionNsfw',
 	PreconditionClientPermissions = 'preconditionClientPermissions',
 	PreconditionClientPermissionsNoClient = 'preconditionClientPermissionsNoClient',
 	PreconditionClientPermissionsNoPermissions = 'preconditionClientPermissionsNoPermissions',
+	PreconditionRunIn = 'preconditionRunIn',
 	PreconditionUserPermissions = 'preconditionUserPermissions',
 	PreconditionUserPermissionsNoPermissions = 'preconditionUserPermissionsNoPermissions',
+	/** @deprecated Use {@link PreconditionRunIn} instead. */
 	PreconditionThreadOnly = 'preconditionThreadOnly',
 
 	PreconditionUnavailable = 'preconditionUnavailable',

--- a/src/lib/structures/Precondition.ts
+++ b/src/lib/structures/Precondition.ts
@@ -2,6 +2,7 @@ import { Piece } from '@sapphire/pieces';
 import { Result } from '@sapphire/result';
 import type { Awaitable } from '@sapphire/utilities';
 import type {
+	ChannelType,
 	ChatInputCommandInteraction,
 	CommandInteraction,
 	ContextMenuCommandInteraction,
@@ -139,6 +140,9 @@ export interface Preconditions {
 	GuildVoiceOnly: never;
 	GuildThreadOnly: never;
 	NSFW: never;
+	RunIn: {
+		types: readonly ChannelType[];
+	};
 	ClientPermissions: {
 		permissions: PermissionsBitField;
 	};

--- a/src/preconditions/DMOnly.ts
+++ b/src/preconditions/DMOnly.ts
@@ -19,7 +19,7 @@ export class CorePrecondition extends AllFlowsPrecondition {
 		return this.error({
 			// eslint-disable-next-line deprecation/deprecation
 			identifier: Identifiers.PreconditionDMOnly,
-			message: 'You cannot run this context menu command outside DMs.'
+			message: 'You cannot run this command outside DMs.'
 		});
 	}
 }

--- a/src/preconditions/DMOnly.ts
+++ b/src/preconditions/DMOnly.ts
@@ -4,20 +4,22 @@ import { AllFlowsPrecondition } from '../lib/structures/Precondition';
 
 export class CorePrecondition extends AllFlowsPrecondition {
 	public messageRun(message: Message): AllFlowsPrecondition.Result {
-		return message.guild === null
-			? this.ok()
-			: this.error({ identifier: Identifiers.PreconditionDMOnly, message: 'You cannot run this message command outside DMs.' });
+		return message.guild === null ? this.ok() : this.makeSharedError();
 	}
 
 	public chatInputRun(interaction: ChatInputCommandInteraction): AllFlowsPrecondition.Result {
-		return interaction.guildId === null
-			? this.ok()
-			: this.error({ identifier: Identifiers.PreconditionDMOnly, message: 'You cannot run this chat input command outside DMs.' });
+		return interaction.guildId === null ? this.ok() : this.makeSharedError();
 	}
 
 	public contextMenuRun(interaction: ContextMenuCommandInteraction): AllFlowsPrecondition.Result {
-		return interaction.guildId === null
-			? this.ok()
-			: this.error({ identifier: Identifiers.PreconditionDMOnly, message: 'You cannot run this context menu command outside DMs.' });
+		return interaction.guildId === null ? this.ok() : this.makeSharedError();
+	}
+
+	private makeSharedError(): AllFlowsPrecondition.Result {
+		return this.error({
+			// eslint-disable-next-line deprecation/deprecation
+			identifier: Identifiers.PreconditionDMOnly,
+			message: 'You cannot run this context menu command outside DMs.'
+		});
 	}
 }

--- a/src/preconditions/GuildNewsOnly.ts
+++ b/src/preconditions/GuildNewsOnly.ts
@@ -6,33 +6,26 @@ export class CorePrecondition extends AllFlowsPrecondition {
 	private readonly allowedTypes: TextBasedChannelTypes[] = [ChannelType.GuildAnnouncement, ChannelType.AnnouncementThread];
 
 	public messageRun(message: Message): AllFlowsPrecondition.Result {
-		return this.allowedTypes.includes(message.channel.type)
-			? this.ok()
-			: this.error({
-					identifier: Identifiers.PreconditionGuildNewsOnly,
-					message: 'You can only run this message command in server announcement channels.'
-			  });
+		return this.allowedTypes.includes(message.channel.type) ? this.ok() : this.makeSharedError();
 	}
 
 	public async chatInputRun(interaction: ChatInputCommandInteraction): AllFlowsPrecondition.AsyncResult {
 		const channel = await this.fetchChannelFromInteraction(interaction);
 
-		return this.allowedTypes.includes(channel.type)
-			? this.ok()
-			: this.error({
-					identifier: Identifiers.PreconditionGuildNewsOnly,
-					message: 'You can only run this chat input command in server announcement channels.'
-			  });
+		return this.allowedTypes.includes(channel.type) ? this.ok() : this.makeSharedError();
 	}
 
 	public async contextMenuRun(interaction: ContextMenuCommandInteraction): AllFlowsPrecondition.AsyncResult {
 		const channel = await this.fetchChannelFromInteraction(interaction);
 
-		return this.allowedTypes.includes(channel.type)
-			? this.ok()
-			: this.error({
-					identifier: Identifiers.PreconditionGuildNewsOnly,
-					message: 'You can only run this context menu command in server announcement channels.'
-			  });
+		return this.allowedTypes.includes(channel.type) ? this.ok() : this.makeSharedError();
+	}
+
+	private makeSharedError(): AllFlowsPrecondition.Result {
+		return this.error({
+			// eslint-disable-next-line deprecation/deprecation
+			identifier: Identifiers.PreconditionGuildNewsOnly,
+			message: 'You can only run this context menu command in server announcement channels.'
+		});
 	}
 }

--- a/src/preconditions/GuildNewsOnly.ts
+++ b/src/preconditions/GuildNewsOnly.ts
@@ -25,7 +25,7 @@ export class CorePrecondition extends AllFlowsPrecondition {
 		return this.error({
 			// eslint-disable-next-line deprecation/deprecation
 			identifier: Identifiers.PreconditionGuildNewsOnly,
-			message: 'You can only run this context menu command in server announcement channels.'
+			message: 'You can only run this command in server announcement channels.'
 		});
 	}
 }

--- a/src/preconditions/GuildNewsThreadOnly.ts
+++ b/src/preconditions/GuildNewsThreadOnly.ts
@@ -4,33 +4,24 @@ import { AllFlowsPrecondition } from '../lib/structures/Precondition';
 
 export class CorePrecondition extends AllFlowsPrecondition {
 	public messageRun(message: Message): AllFlowsPrecondition.Result {
-		return message.thread?.type === ChannelType.AnnouncementThread
-			? this.ok()
-			: this.error({
-					identifier: Identifiers.PreconditionGuildNewsThreadOnly,
-					message: 'You can only run this message command in server announcement thread channels.'
-			  });
+		return message.thread?.type === ChannelType.AnnouncementThread ? this.ok() : this.makeSharedError();
 	}
 
 	public async chatInputRun(interaction: ChatInputCommandInteraction): AllFlowsPrecondition.AsyncResult {
 		const channel = await this.fetchChannelFromInteraction(interaction);
-
-		return channel.type === ChannelType.AnnouncementThread
-			? this.ok()
-			: this.error({
-					identifier: Identifiers.PreconditionGuildNewsThreadOnly,
-					message: 'You can only run this chat input command in server announcement thread channels.'
-			  });
+		return channel.type === ChannelType.AnnouncementThread ? this.ok() : this.makeSharedError();
 	}
 
 	public async contextMenuRun(interaction: ContextMenuCommandInteraction): AllFlowsPrecondition.AsyncResult {
 		const channel = await this.fetchChannelFromInteraction(interaction);
+		return channel.type === ChannelType.AnnouncementThread ? this.ok() : this.makeSharedError();
+	}
 
-		return channel.type === ChannelType.AnnouncementThread
-			? this.ok()
-			: this.error({
-					identifier: Identifiers.PreconditionGuildNewsThreadOnly,
-					message: 'You can only run this context menu command in server announcement thread channels.'
-			  });
+	private makeSharedError(): AllFlowsPrecondition.Result {
+		return this.error({
+			// eslint-disable-next-line deprecation/deprecation
+			identifier: Identifiers.PreconditionGuildNewsThreadOnly,
+			message: 'You can only run this context menu command in server announcement thread channels.'
+		});
 	}
 }

--- a/src/preconditions/GuildNewsThreadOnly.ts
+++ b/src/preconditions/GuildNewsThreadOnly.ts
@@ -21,7 +21,7 @@ export class CorePrecondition extends AllFlowsPrecondition {
 		return this.error({
 			// eslint-disable-next-line deprecation/deprecation
 			identifier: Identifiers.PreconditionGuildNewsThreadOnly,
-			message: 'You can only run this context menu command in server announcement thread channels.'
+			message: 'You can only run this command in server announcement thread channels.'
 		});
 	}
 }

--- a/src/preconditions/GuildOnly.ts
+++ b/src/preconditions/GuildOnly.ts
@@ -19,7 +19,7 @@ export class CorePrecondition extends AllFlowsPrecondition {
 		return this.error({
 			// eslint-disable-next-line deprecation/deprecation
 			identifier: Identifiers.PreconditionGuildOnly,
-			message: 'You cannot run this context menu command in DMs.'
+			message: 'You cannot run this command in DMs.'
 		});
 	}
 }

--- a/src/preconditions/GuildOnly.ts
+++ b/src/preconditions/GuildOnly.ts
@@ -4,20 +4,22 @@ import { AllFlowsPrecondition } from '../lib/structures/Precondition';
 
 export class CorePrecondition extends AllFlowsPrecondition {
 	public messageRun(message: Message): AllFlowsPrecondition.Result {
-		return message.guildId === null
-			? this.error({ identifier: Identifiers.PreconditionGuildOnly, message: 'You cannot run this message command in DMs.' })
-			: this.ok();
+		return message.guildId === null ? this.makeSharedError() : this.ok();
 	}
 
 	public chatInputRun(interaction: ChatInputCommandInteraction): AllFlowsPrecondition.Result {
-		return interaction.guildId === null
-			? this.error({ identifier: Identifiers.PreconditionGuildOnly, message: 'You cannot run this chat input command in DMs.' })
-			: this.ok();
+		return interaction.guildId === null ? this.makeSharedError() : this.ok();
 	}
 
 	public contextMenuRun(interaction: ContextMenuCommandInteraction): AllFlowsPrecondition.Result {
-		return interaction.guildId === null
-			? this.error({ identifier: Identifiers.PreconditionGuildOnly, message: 'You cannot run this context menu command in DMs.' })
-			: this.ok();
+		return interaction.guildId === null ? this.makeSharedError() : this.ok();
+	}
+
+	private makeSharedError(): AllFlowsPrecondition.Result {
+		return this.error({
+			// eslint-disable-next-line deprecation/deprecation
+			identifier: Identifiers.PreconditionGuildOnly,
+			message: 'You cannot run this context menu command in DMs.'
+		});
 	}
 }

--- a/src/preconditions/GuildPrivateThreadOnly.ts
+++ b/src/preconditions/GuildPrivateThreadOnly.ts
@@ -4,33 +4,24 @@ import { AllFlowsPrecondition } from '../lib/structures/Precondition';
 
 export class CorePrecondition extends AllFlowsPrecondition {
 	public messageRun(message: Message): AllFlowsPrecondition.Result {
-		return message.thread?.type === ChannelType.PrivateThread
-			? this.ok()
-			: this.error({
-					identifier: Identifiers.PreconditionGuildPrivateThreadOnly,
-					message: 'You can only run this message command in private server thread channels.'
-			  });
+		return message.thread?.type === ChannelType.PrivateThread ? this.ok() : this.makeSharedError();
 	}
 
 	public async chatInputRun(interaction: ChatInputCommandInteraction): AllFlowsPrecondition.AsyncResult {
 		const channel = await this.fetchChannelFromInteraction(interaction);
-
-		return channel.type === ChannelType.PrivateThread
-			? this.ok()
-			: this.error({
-					identifier: Identifiers.PreconditionGuildPrivateThreadOnly,
-					message: 'You can only run this chat input command in private server thread channels.'
-			  });
+		return channel.type === ChannelType.PrivateThread ? this.ok() : this.makeSharedError();
 	}
 
 	public async contextMenuRun(interaction: ContextMenuCommandInteraction): AllFlowsPrecondition.AsyncResult {
 		const channel = await this.fetchChannelFromInteraction(interaction);
+		return channel.type === ChannelType.PrivateThread ? this.ok() : this.makeSharedError();
+	}
 
-		return channel.type === ChannelType.PrivateThread
-			? this.ok()
-			: this.error({
-					identifier: Identifiers.PreconditionGuildPrivateThreadOnly,
-					message: 'You can only run this context menu command in private server thread channels.'
-			  });
+	private makeSharedError(): AllFlowsPrecondition.Result {
+		return this.error({
+			// eslint-disable-next-line deprecation/deprecation
+			identifier: Identifiers.PreconditionGuildPrivateThreadOnly,
+			message: 'You can only run this context menu command in private server thread channels.'
+		});
 	}
 }

--- a/src/preconditions/GuildPrivateThreadOnly.ts
+++ b/src/preconditions/GuildPrivateThreadOnly.ts
@@ -21,7 +21,7 @@ export class CorePrecondition extends AllFlowsPrecondition {
 		return this.error({
 			// eslint-disable-next-line deprecation/deprecation
 			identifier: Identifiers.PreconditionGuildPrivateThreadOnly,
-			message: 'You can only run this context menu command in private server thread channels.'
+			message: 'You can only run this command in private server thread channels.'
 		});
 	}
 }

--- a/src/preconditions/GuildPublicThreadOnly.ts
+++ b/src/preconditions/GuildPublicThreadOnly.ts
@@ -21,7 +21,7 @@ export class CorePrecondition extends AllFlowsPrecondition {
 		return this.error({
 			// eslint-disable-next-line deprecation/deprecation
 			identifier: Identifiers.PreconditionGuildPublicThreadOnly,
-			message: 'You can only run this context menu command in public server thread channels.'
+			message: 'You can only run this command in public server thread channels.'
 		});
 	}
 }

--- a/src/preconditions/GuildPublicThreadOnly.ts
+++ b/src/preconditions/GuildPublicThreadOnly.ts
@@ -4,33 +4,24 @@ import { AllFlowsPrecondition } from '../lib/structures/Precondition';
 
 export class CorePrecondition extends AllFlowsPrecondition {
 	public messageRun(message: Message): AllFlowsPrecondition.Result {
-		return message.thread?.type === ChannelType.PublicThread
-			? this.ok()
-			: this.error({
-					identifier: Identifiers.PreconditionGuildPublicThreadOnly,
-					message: 'You can only run this message command in public server thread channels.'
-			  });
+		return message.thread?.type === ChannelType.PublicThread ? this.ok() : this.makeSharedError();
 	}
 
 	public async chatInputRun(interaction: ChatInputCommandInteraction): AllFlowsPrecondition.AsyncResult {
 		const channel = await this.fetchChannelFromInteraction(interaction);
-
-		return channel.type === ChannelType.PublicThread
-			? this.ok()
-			: this.error({
-					identifier: Identifiers.PreconditionGuildPublicThreadOnly,
-					message: 'You can only run this chat input command in public server thread channels.'
-			  });
+		return channel.type === ChannelType.PublicThread ? this.ok() : this.makeSharedError();
 	}
 
 	public async contextMenuRun(interaction: ContextMenuCommandInteraction): AllFlowsPrecondition.AsyncResult {
 		const channel = await this.fetchChannelFromInteraction(interaction);
+		return channel.type === ChannelType.PublicThread ? this.ok() : this.makeSharedError();
+	}
 
-		return channel.type === ChannelType.PublicThread
-			? this.ok()
-			: this.error({
-					identifier: Identifiers.PreconditionGuildPublicThreadOnly,
-					message: 'You can only run this context menu command in public server thread channels.'
-			  });
+	private makeSharedError(): AllFlowsPrecondition.Result {
+		return this.error({
+			// eslint-disable-next-line deprecation/deprecation
+			identifier: Identifiers.PreconditionGuildPublicThreadOnly,
+			message: 'You can only run this context menu command in public server thread channels.'
+		});
 	}
 }

--- a/src/preconditions/GuildTextOnly.ts
+++ b/src/preconditions/GuildTextOnly.ts
@@ -23,7 +23,7 @@ export class CorePrecondition extends AllFlowsPrecondition {
 		return this.error({
 			// eslint-disable-next-line deprecation/deprecation
 			identifier: Identifiers.PreconditionGuildTextOnly,
-			message: 'You can only run this context menu command in server text channels.'
+			message: 'You can only run this command in server text channels.'
 		});
 	}
 }

--- a/src/preconditions/GuildTextOnly.ts
+++ b/src/preconditions/GuildTextOnly.ts
@@ -6,33 +6,24 @@ export class CorePrecondition extends AllFlowsPrecondition {
 	private readonly allowedTypes: TextBasedChannelTypes[] = [ChannelType.GuildText, ChannelType.PublicThread, ChannelType.PrivateThread];
 
 	public messageRun(message: Message): AllFlowsPrecondition.Result {
-		return this.allowedTypes.includes(message.channel.type)
-			? this.ok()
-			: this.error({
-					identifier: Identifiers.PreconditionGuildTextOnly,
-					message: 'You can only run this message command in server text channels.'
-			  });
+		return this.allowedTypes.includes(message.channel.type) ? this.ok() : this.makeSharedError();
 	}
 
 	public async chatInputRun(interaction: ChatInputCommandInteraction): AllFlowsPrecondition.AsyncResult {
 		const channel = await this.fetchChannelFromInteraction(interaction);
-
-		return this.allowedTypes.includes(channel.type)
-			? this.ok()
-			: this.error({
-					identifier: Identifiers.PreconditionGuildTextOnly,
-					message: 'You can only run this chat input command in server text channels.'
-			  });
+		return this.allowedTypes.includes(channel.type) ? this.ok() : this.makeSharedError();
 	}
 
 	public async contextMenuRun(interaction: ContextMenuCommandInteraction): AllFlowsPrecondition.AsyncResult {
 		const channel = await this.fetchChannelFromInteraction(interaction);
+		return this.allowedTypes.includes(channel.type) ? this.ok() : this.makeSharedError();
+	}
 
-		return this.allowedTypes.includes(channel.type)
-			? this.ok()
-			: this.error({
-					identifier: Identifiers.PreconditionGuildTextOnly,
-					message: 'You can only run this context menu command in server text channels.'
-			  });
+	private makeSharedError(): AllFlowsPrecondition.Result {
+		return this.error({
+			// eslint-disable-next-line deprecation/deprecation
+			identifier: Identifiers.PreconditionGuildTextOnly,
+			message: 'You can only run this context menu command in server text channels.'
+		});
 	}
 }

--- a/src/preconditions/GuildThreadOnly.ts
+++ b/src/preconditions/GuildThreadOnly.ts
@@ -4,33 +4,24 @@ import { AllFlowsPrecondition } from '../lib/structures/Precondition';
 
 export class CorePrecondition extends AllFlowsPrecondition {
 	public messageRun(message: Message): AllFlowsPrecondition.Result {
-		return message.thread
-			? this.ok()
-			: this.error({
-					identifier: Identifiers.PreconditionThreadOnly,
-					message: 'You can only run this message command in server thread channels.'
-			  });
+		return message.thread ? this.ok() : this.makeSharedError();
 	}
 
 	public async chatInputRun(interaction: ChatInputCommandInteraction): AllFlowsPrecondition.AsyncResult {
 		const channel = await this.fetchChannelFromInteraction(interaction);
-
-		return channel.isThread()
-			? this.ok()
-			: this.error({
-					identifier: Identifiers.PreconditionThreadOnly,
-					message: 'You can only run this chat input command in server thread channels.'
-			  });
+		return channel.isThread() ? this.ok() : this.makeSharedError();
 	}
 
 	public async contextMenuRun(interaction: ContextMenuCommandInteraction): AllFlowsPrecondition.AsyncResult {
 		const channel = await this.fetchChannelFromInteraction(interaction);
+		return channel.isThread() ? this.ok() : this.makeSharedError();
+	}
 
-		return channel.isThread()
-			? this.ok()
-			: this.error({
-					identifier: Identifiers.PreconditionThreadOnly,
-					message: 'You can only run this context menu command in server thread channels.'
-			  });
+	private makeSharedError(): AllFlowsPrecondition.Result {
+		return this.error({
+			// eslint-disable-next-line deprecation/deprecation
+			identifier: Identifiers.PreconditionThreadOnly,
+			message: 'You can only run this context menu command in server thread channels.'
+		});
 	}
 }

--- a/src/preconditions/GuildThreadOnly.ts
+++ b/src/preconditions/GuildThreadOnly.ts
@@ -21,7 +21,7 @@ export class CorePrecondition extends AllFlowsPrecondition {
 		return this.error({
 			// eslint-disable-next-line deprecation/deprecation
 			identifier: Identifiers.PreconditionThreadOnly,
-			message: 'You can only run this context menu command in server thread channels.'
+			message: 'You can only run this command in server thread channels.'
 		});
 	}
 }

--- a/src/preconditions/GuildVoiceOnly.ts
+++ b/src/preconditions/GuildVoiceOnly.ts
@@ -22,7 +22,7 @@ export class CorePrecondition extends AllFlowsPrecondition {
 		return this.error({
 			// eslint-disable-next-line deprecation/deprecation
 			identifier: Identifiers.PreconditionGuildVoiceOnly,
-			message: 'You can only run this context menu command in server voice channels.'
+			message: 'You can only run this command in server voice channels.'
 		});
 	}
 }

--- a/src/preconditions/GuildVoiceOnly.ts
+++ b/src/preconditions/GuildVoiceOnly.ts
@@ -5,33 +5,24 @@ import { AllFlowsPrecondition } from '../lib/structures/Precondition';
 
 export class CorePrecondition extends AllFlowsPrecondition {
 	public messageRun(message: Message): AllFlowsPrecondition.Result {
-		return isVoiceChannel(message.channel)
-			? this.ok()
-			: this.error({
-					identifier: Identifiers.PreconditionGuildVoiceOnly,
-					message: 'You can only run this message command in server voice channels.'
-			  });
+		return isVoiceChannel(message.channel) ? this.ok() : this.makeSharedError();
 	}
 
 	public async chatInputRun(interaction: ChatInputCommandInteraction): AllFlowsPrecondition.AsyncResult {
 		const channel = await this.fetchChannelFromInteraction(interaction);
-
-		return isVoiceChannel(channel)
-			? this.ok()
-			: this.error({
-					identifier: Identifiers.PreconditionGuildVoiceOnly,
-					message: 'You can only run this chat input command in server voice channels.'
-			  });
+		return isVoiceChannel(channel) ? this.ok() : this.makeSharedError();
 	}
 
 	public async contextMenuRun(interaction: ContextMenuCommandInteraction): AllFlowsPrecondition.AsyncResult {
 		const channel = await this.fetchChannelFromInteraction(interaction);
+		return isVoiceChannel(channel) ? this.ok() : this.makeSharedError();
+	}
 
-		return isVoiceChannel(channel)
-			? this.ok()
-			: this.error({
-					identifier: Identifiers.PreconditionGuildVoiceOnly,
-					message: 'You can only run this context menu command in server voice channels.'
-			  });
+	private makeSharedError(): AllFlowsPrecondition.Result {
+		return this.error({
+			// eslint-disable-next-line deprecation/deprecation
+			identifier: Identifiers.PreconditionGuildVoiceOnly,
+			message: 'You can only run this context menu command in server voice channels.'
+		});
 	}
 }

--- a/src/preconditions/NSFW.ts
+++ b/src/preconditions/NSFW.ts
@@ -28,6 +28,6 @@ export class CorePrecondition extends AllFlowsPrecondition {
 		// will result on it returning `false`.
 		return Reflect.get(channel, 'nsfw') === true
 			? this.ok()
-			: this.error({ identifier: Identifiers.PreconditionNSFW, message: 'You cannot run this context menu command outside NSFW channels.' });
+			: this.error({ identifier: Identifiers.PreconditionNSFW, message: 'You cannot run this command outside NSFW channels.' });
 	}
 }

--- a/src/preconditions/RunIn.ts
+++ b/src/preconditions/RunIn.ts
@@ -1,0 +1,44 @@
+import type { ChannelType, ChatInputCommandInteraction, ContextMenuCommandInteraction, Message } from 'discord.js';
+import { Identifiers } from '../lib/errors/Identifiers';
+import type { ChatInputCommand, ContextMenuCommand, MessageCommand } from '../lib/structures/Command';
+import { AllFlowsPrecondition } from '../lib/structures/Precondition';
+
+export interface RunInPreconditionContext extends AllFlowsPrecondition.Context {
+	types?: readonly ChannelType[];
+}
+
+export class CorePrecondition extends AllFlowsPrecondition {
+	public override messageRun(message: Message<boolean>, _: MessageCommand, context: RunInPreconditionContext): AllFlowsPrecondition.Result {
+		return context.types && context.types.includes(message.channel.type) //
+			? this.ok()
+			: this.makeSharedError(context);
+	}
+
+	public override async chatInputRun(
+		interaction: ChatInputCommandInteraction,
+		_: ChatInputCommand,
+		context: RunInPreconditionContext
+	): AllFlowsPrecondition.AsyncResult {
+		return context.types && context.types.includes((await this.fetchChannelFromInteraction(interaction)).type)
+			? this.ok()
+			: this.makeSharedError(context);
+	}
+
+	public override async contextMenuRun(
+		interaction: ContextMenuCommandInteraction,
+		_: ContextMenuCommand,
+		context: RunInPreconditionContext
+	): AllFlowsPrecondition.AsyncResult {
+		return context.types && context.types.includes((await this.fetchChannelFromInteraction(interaction)).type)
+			? this.ok()
+			: this.makeSharedError(context);
+	}
+
+	private makeSharedError(context: RunInPreconditionContext): AllFlowsPrecondition.Result {
+		return this.error({
+			identifier: Identifiers.PreconditionRunIn,
+			message: 'You cannot run this message command in this type of channel.',
+			context: { types: context.types }
+		});
+	}
+}


### PR DESCRIPTION
Fixes the issue in thread [`#Eventho runIn has values Guildtext and dm, if run in guild text, error message is shown`](https://discord.com/channels/737141877803057244/1073022367070162955).

I deprecated the following preconditions:

- `DMOnly`
- `GuildNewsOnly`
- `GuildNewsThreadOnly`
- `GuildOnly`
- `GuildPrivateThreadOnly`
- `GuildPublicThreadOnly`
- `GuildTextOnly`
- `GuildThreadOnly`
- `GuildVoiceOnly`

The reason why they were so many different preconditions in the first place, was because:

- Preconditions were added manually, context was bothersome to include **(pre-v2)**.
- Preconditions did very fast synchronous checks **(pre-v3)**.
  - It's encouraged to use interactions instead, which would use `await this.fetchChannelFromInteraction(interaction)` for every single precondition.

Further than that, this design proved several flaws:

- High code duplication in all preconditions.
- High complexity of the `runIn` type optimizer as new entries were added.
  - *Plus chances of this behaviour changing when Discord added new channels.*
- Support for new channel types had to be done manually.
  - No voice channel or stage voice channel support as of this PR despite being available for a long time.
- The displayed error would be the last precondition of the RunIn sub-array, as it doesn't have knowledge of the other supported types.

`RunIn`, however, has an extra complexity in translating if it's desired to display the keys, but its pros outweight the aforementioned flaws of the current design.
