### PR TITLE
refactor: move command types to its own file

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,7 @@ export * from './lib/structures/ListenerStore';
 export * from './lib/structures/Precondition';
 export * from './lib/structures/PreconditionStore';
 export * from './lib/types/ArgumentContexts';
+export * from './lib/types/CommandTypes';
 export * from './lib/types/Enums';
 export * from './lib/types/Events';
 export {

--- a/src/lib/parsers/Args.ts
+++ b/src/lib/parsers/Args.ts
@@ -23,7 +23,7 @@ import { Identifiers } from '../errors/Identifiers';
 import { UserError } from '../errors/UserError';
 import type { EmojiObject } from '../resolvers/emoji';
 import type { Argument, IArgument } from '../structures/Argument';
-import type { MessageCommand } from '../structures/Command';
+import type { MessageCommand } from '../types/CommandTypes';
 
 /**
  * The argument parser to be used in {@link Command}.

--- a/src/lib/structures/Argument.ts
+++ b/src/lib/structures/Argument.ts
@@ -4,8 +4,8 @@ import type { Awaitable } from '@sapphire/utilities';
 import type { Message } from 'discord.js';
 import type { ArgumentError } from '../errors/ArgumentError';
 import { Args } from '../parsers/Args';
+import type { MessageCommand } from '../types/CommandTypes';
 import type { ArgumentStore } from './ArgumentStore';
-import type { MessageCommand } from './Command';
 
 /**
  * Defines a synchronous result of an {@link Argument}, check {@link Argument.AsyncResult} for the asynchronous version.

--- a/src/lib/structures/Command.ts
+++ b/src/lib/structures/Command.ts
@@ -1,24 +1,34 @@
 import { ArgumentStream, Lexer, Parser, type IUnorderedStrategy } from '@sapphire/lexure';
-import { AliasPiece, type AliasPieceJSON } from '@sapphire/pieces';
-import { isNullish, isObject, type Awaitable, type NonNullObject, type Nullish } from '@sapphire/utilities';
+import { AliasPiece } from '@sapphire/pieces';
+import { isNullish, isObject, type Awaitable } from '@sapphire/utilities';
 import {
 	ChannelType,
 	ChatInputCommandInteraction,
 	ContextMenuCommandInteraction,
 	PermissionsBitField,
 	type AutocompleteInteraction,
-	type Message,
-	type PermissionResolvable,
-	type Snowflake
+	type Message
 } from 'discord.js';
 import { Args } from '../parsers/Args';
-import { BucketScope, RegisterBehavior } from '../types/Enums';
+import type {
+	AutocompleteCommand,
+	ChatInputCommand,
+	CommandJSON,
+	CommandOptions,
+	CommandOptionsRunType,
+	CommandRunInUnion,
+	CommandSpecificRunIn,
+	ContextMenuCommand,
+	DetailedDescriptionCommand,
+	MessageCommand
+} from '../types/CommandTypes';
+import { BucketScope, CommandPreConditions, RegisterBehavior } from '../types/Enums';
 import { acquire, getDefaultBehaviorWhenNotIdentical, handleBulkOverwrite } from '../utils/application-commands/ApplicationCommandRegistries';
 import type { ApplicationCommandRegistry } from '../utils/application-commands/ApplicationCommandRegistry';
 import { getNeededRegistryParameters } from '../utils/application-commands/getNeededParameters';
 import { emitPerRegistryError } from '../utils/application-commands/registriesErrors';
-import { PreconditionContainerArray, type PreconditionEntryResolvable } from '../utils/preconditions/PreconditionContainerArray';
-import { FlagUnorderedStrategy, type FlagStrategyOptions } from '../utils/strategies/FlagUnorderedStrategy';
+import { PreconditionContainerArray } from '../utils/preconditions/PreconditionContainerArray';
+import { FlagUnorderedStrategy } from '../utils/strategies/FlagUnorderedStrategy';
 import type { CommandStore } from './CommandStore';
 
 const ChannelTypes = Object.values(ChannelType).filter((type) => typeof type === 'number') as readonly ChannelType[];
@@ -500,331 +510,6 @@ export class Command<PreParseReturn = Args, O extends Command.Options = Command.
 	}
 }
 
-export type MessageCommand = Command & Required<Pick<Command, 'messageRun'>>;
-
-export namespace MessageCommand {
-	export type Options = CommandOptions;
-	export type JSON = CommandJSON;
-	export type Context = AliasPiece.Context;
-	export type RunInTypes = CommandOptionsRunType;
-	export type RunContext = MessageCommandContext;
-}
-
-export type ChatInputCommand = Command & Required<Pick<Command, 'chatInputRun'>>;
-
-export namespace ChatInputCommand {
-	export type Options = CommandOptions;
-	export type JSON = CommandJSON;
-	export type Context = AliasPiece.Context;
-	export type RunInTypes = CommandOptionsRunType;
-	export type RunContext = ChatInputCommandContext;
-	export type Interaction<Cached extends import('discord.js').CacheType = import('discord.js').CacheType> = ChatInputCommandInteraction<Cached>;
-	export type Registry = ApplicationCommandRegistry;
-}
-
-export type ContextMenuCommand = Command & Required<Pick<Command, 'contextMenuRun'>>;
-
-export namespace ContextMenuCommand {
-	export type Options = CommandOptions;
-	export type JSON = CommandJSON;
-	export type Context = AliasPiece.Context;
-	export type RunInTypes = CommandOptionsRunType;
-	export type RunContext = ContextMenuCommandContext;
-	export type Interaction<Cached extends import('discord.js').CacheType = import('discord.js').CacheType> = ContextMenuCommandInteraction<Cached>;
-	export type Registry = ApplicationCommandRegistry;
-}
-
-export type AutocompleteCommand = Command & Required<Pick<Command, 'autocompleteRun'>>;
-
-export namespace AutocompleteCommand {
-	export type Options = CommandOptions;
-	export type JSON = CommandJSON;
-	export type Context = AliasPiece.Context;
-	export type RunInTypes = CommandOptionsRunType;
-	export type RunContext = AutocompleteCommandContext;
-	export type Interaction<Cached extends import('discord.js').CacheType = import('discord.js').CacheType> = AutocompleteInteraction<Cached>;
-	export type Registry = ApplicationCommandRegistry;
-}
-
-/**
- * The allowed values for {@link Command.Options.runIn}.
- * @remark It is discouraged to use this type, we recommend using {@link CommandOptionsRunTypeEnum} instead.
- * @since 2.0.0
- */
-export type CommandOptionsRunType =
-	| 'DM'
-	| 'GUILD_TEXT'
-	| 'GUILD_VOICE'
-	| 'GUILD_NEWS'
-	| 'GUILD_NEWS_THREAD'
-	| 'GUILD_PUBLIC_THREAD'
-	| 'GUILD_PRIVATE_THREAD'
-	| 'GUILD_ANY';
-
-/**
- * The allowed values for {@link CommandOptions.runIn}.
- * @since 4.7.0
- */
-export type CommandRunInUnion =
-	| ChannelType
-	| Command.RunInTypes
-	| CommandOptionsRunTypeEnum
-	| readonly (ChannelType | Command.RunInTypes | CommandOptionsRunTypeEnum)[]
-	| Nullish;
-
-/**
- * A more detailed structure for {@link CommandOptions.runIn} when you want to have a different `runIn` for each
- * command type.
- * @since 4.7.0
- */
-export interface CommandSpecificRunIn {
-	chatInputRun?: CommandRunInUnion;
-	messageRun?: CommandRunInUnion;
-	contextMenuRun?: CommandRunInUnion;
-}
-
-/**
- * The allowed values for {@link Command.Options.runIn} as an enum.
- * @since 2.0.0
- */
-export enum CommandOptionsRunTypeEnum {
-	Dm = 'DM',
-	GuildText = 'GUILD_TEXT',
-	GuildVoice = 'GUILD_VOICE',
-	GuildNews = 'GUILD_NEWS',
-	GuildNewsThread = 'GUILD_NEWS_THREAD',
-	GuildPublicThread = 'GUILD_PUBLIC_THREAD',
-	GuildPrivateThread = 'GUILD_PRIVATE_THREAD',
-	GuildAny = 'GUILD_ANY'
-}
-
-/**
- * The available command pre-conditions.
- * @since 2.0.0
- */
-export enum CommandPreConditions {
-	Cooldown = 'Cooldown',
-	/** @deprecated Use {@link RunIn} instead. */
-	DirectMessageOnly = 'DMOnly',
-	RunIn = 'RunIn',
-	/** @deprecated Use {@link RunIn} instead. */
-	GuildNewsOnly = 'GuildNewsOnly',
-	/** @deprecated Use {@link RunIn} instead. */
-	GuildNewsThreadOnly = 'GuildNewsThreadOnly',
-	/** @deprecated Use {@link RunIn} instead. */
-	GuildOnly = 'GuildOnly',
-	/** @deprecated Use {@link RunIn} instead. */
-	GuildPrivateThreadOnly = 'GuildPrivateThreadOnly',
-	/** @deprecated Use {@link RunIn} instead. */
-	GuildPublicThreadOnly = 'GuildPublicThreadOnly',
-	/** @deprecated Use {@link RunIn} instead. */
-	GuildTextOnly = 'GuildTextOnly',
-	/** @deprecated Use {@link RunIn} instead. */
-	GuildVoiceOnly = 'GuildVoiceOnly',
-	/** @deprecated Use {@link RunIn} instead. */
-	GuildThreadOnly = 'GuildThreadOnly',
-	NotSafeForWork = 'NSFW',
-	ClientPermissions = 'ClientPermissions',
-	UserPermissions = 'UserPermissions'
-}
-
-/**
- * The {@link Command} options.
- * @since 1.0.0
- */
-export interface CommandOptions extends AliasPiece.Options, FlagStrategyOptions {
-	/**
-	 * Whether to add aliases for commands with dashes in them
-	 * @since 1.0.0
-	 * @default false
-	 */
-	generateDashLessAliases?: boolean;
-
-	/**
-	 * Whether to add aliases for commands with underscores in them
-	 * @since 3.0.0
-	 * @default false
-	 */
-	generateUnderscoreLessAliases?: boolean;
-
-	/**
-	 * The description for the command.
-	 * @since 1.0.0
-	 * @default ''
-	 */
-	description?: string;
-
-	/**
-	 * The detailed description for the command.
-	 * @since 1.0.0
-	 * @default ''
-	 */
-	detailedDescription?: DetailedDescriptionCommand;
-
-	/**
-	 * The full category path for the command
-	 * @since 2.0.0
-	 * @default 'An array of folder names that lead back to the folder that is registered for in the commands store'
-	 * @example
-	 * ```typescript
-	 * // Given a file named `ping.js` at the path of `commands/General/ping.js`
-	 * ['General']
-	 *
-	 * // Given a file named `info.js` at the path of `commands/General/About/ping.js`
-	 * ['General', 'About']
-	 * ```
-	 */
-	fullCategory?: string[];
-
-	/**
-	 * The {@link Precondition}s to be run, accepts an array of their names.
-	 * @seealso {@link PreconditionContainerArray}
-	 * @since 1.0.0
-	 * @default []
-	 */
-	preconditions?: readonly PreconditionEntryResolvable[];
-
-	/**
-	 * The quotes accepted by this command, pass `[]` to disable them.
-	 * @since 1.0.0
-	 * @default
-	 * [
-	 *   ['"', '"'], // Double quotes
-	 *   ['“', '”'], // Fancy quotes (on iOS)
-	 *   ['「', '」'] // Corner brackets (CJK)
-	 *   ['«', '»'] // French quotes (guillemets)
-	 * ]
-	 */
-	quotes?: [string, string][];
-
-	/**
-	 * Sets whether the command should be treated as NSFW. If set to true, the `NSFW` precondition will be added to the list.
-	 * @since 2.0.0
-	 * @default false
-	 */
-	nsfw?: boolean;
-
-	/**
-	 * The amount of entries the cooldown can have before filling up, if set to a non-zero value alongside {@link Command.Options.cooldownDelay}, the `Cooldown` precondition will be added to the list.
-	 * @since 2.0.0
-	 * @default 1
-	 */
-	cooldownLimit?: number;
-
-	/**
-	 * The time in milliseconds for the cooldown entries to reset, if set to a non-zero value alongside {@link Command.Options.cooldownLimit}, the `Cooldown` precondition will be added to the list.
-	 * @since 2.0.0
-	 * @default 0
-	 */
-	cooldownDelay?: number;
-
-	/**
-	 * The scope of the cooldown entries.
-	 * @since 2.0.0
-	 * @default BucketScope.User
-	 */
-	cooldownScope?: BucketScope;
-
-	/**
-	 * The users that are exempt from the Cooldown precondition.
-	 * Use this to filter out someone like a bot owner
-	 * @since 2.0.0
-	 * @default undefined
-	 */
-	cooldownFilteredUsers?: Snowflake[];
-
-	/**
-	 * The required permissions for the client.
-	 * @since 2.0.0
-	 * @default 0
-	 */
-	requiredClientPermissions?: PermissionResolvable;
-
-	/**
-	 * The required permissions for the user.
-	 * @since 2.0.0
-	 * @default 0
-	 */
-	requiredUserPermissions?: PermissionResolvable;
-
-	/**
-	 * The channels the command should run in. If set to `null`, no precondition entry will be added.
-	 * Some optimizations are applied when given an array to reduce the amount of preconditions run
-	 * (e.g. `'GUILD_TEXT'` and `'GUILD_NEWS'` becomes `'GUILD_ANY'`, and if both `'DM'` and `'GUILD_ANY'` are defined,
-	 * then no precondition entry is added as it runs in all channels).
-	 *
-	 * This can be both {@link CommandRunInUnion} which will have the same precondition apply to all the types of commands,
-	 * or you can use {@link CommandSpecificRunIn} to apply different preconditions to different types of commands.
-	 * @since 2.0.0
-	 * @default null
-	 */
-	runIn?: CommandRunInUnion | CommandSpecificRunIn;
-
-	/**
-	 * If {@link SapphireClient.typing} is true, this option will override it.
-	 * Otherwise, this option has no effect - you may call {@link Channel#sendTyping}` in the run method if you want specific commands to display the typing status.
-	 * @default true
-	 */
-	typing?: boolean;
-}
-
-export interface MessageCommandContext extends Record<PropertyKey, unknown> {
-	/**
-	 * The prefix used to run this command.
-	 *
-	 * This is a string for the mention and default prefix, and a RegExp for the `regexPrefix`.
-	 */
-	prefix: string | RegExp;
-	/**
-	 * The alias used to run this command.
-	 */
-	commandName: string;
-	/**
-	 * The matched prefix, this will always be the same as {@link MessageCommand.RunContext.prefix} if it was a string, otherwise it is
-	 * the result of doing `prefix.exec(content)[0]`.
-	 */
-	commandPrefix: string;
-}
-
-export interface ChatInputCommandContext extends Record<PropertyKey, unknown> {
-	/**
-	 * The name of the command.
-	 */
-	commandName: string;
-	/**
-	 * The id of the command.
-	 */
-	commandId: string;
-}
-
-export interface ContextMenuCommandContext extends Record<PropertyKey, unknown> {
-	/**
-	 * The name of the command.
-	 */
-	commandName: string;
-	/**
-	 * The id of the command.
-	 */
-	commandId: string;
-}
-
-export interface AutocompleteCommandContext extends Record<PropertyKey, unknown> {
-	/**
-	 * The name of the command.
-	 */
-	commandName: string;
-	/**
-	 * The id of the command.
-	 */
-	commandId: string;
-}
-
-export interface CommandJSON extends AliasPieceJSON {
-	description: string;
-	detailedDescription: DetailedDescriptionCommand;
-	category: string | null;
-}
-
 export namespace Command {
 	export type Options = CommandOptions;
 	export type JSON = CommandJSON;
@@ -840,7 +525,3 @@ export namespace Command {
 		import('discord.js').AutocompleteInteraction<Cached>;
 	export type Registry = ApplicationCommandRegistry;
 }
-
-export type DetailedDescriptionCommand = string | DetailedDescriptionCommandObject;
-
-export interface DetailedDescriptionCommandObject extends NonNullObject {}

--- a/src/lib/structures/Precondition.ts
+++ b/src/lib/structures/Precondition.ts
@@ -13,7 +13,7 @@ import type {
 import type { CooldownPreconditionContext } from '../../preconditions/Cooldown';
 import { PreconditionError } from '../errors/PreconditionError';
 import type { UserError } from '../errors/UserError';
-import type { ChatInputCommand, ContextMenuCommand, MessageCommand } from './Command';
+import type { ChatInputCommand, ContextMenuCommand, MessageCommand } from '../types/CommandTypes';
 import type { PreconditionStore } from './PreconditionStore';
 
 export type PreconditionResult = Awaitable<Result<unknown, UserError>>;

--- a/src/lib/structures/PreconditionStore.ts
+++ b/src/lib/structures/PreconditionStore.ts
@@ -2,7 +2,7 @@ import { Store } from '@sapphire/pieces';
 import { Result } from '@sapphire/result';
 import type { ChatInputCommandInteraction, ContextMenuCommandInteraction, Message } from 'discord.js';
 import { Identifiers } from '../errors/Identifiers';
-import type { ChatInputCommand, ContextMenuCommand, MessageCommand } from './Command';
+import type { ChatInputCommand, ContextMenuCommand, MessageCommand } from '../types/CommandTypes';
 import { Precondition, type AsyncPreconditionResult } from './Precondition';
 
 export class PreconditionStore extends Store<Precondition> {

--- a/src/lib/types/CommandTypes.ts
+++ b/src/lib/types/CommandTypes.ts
@@ -1,0 +1,299 @@
+import { AliasPiece, type AliasPieceJSON } from '@sapphire/pieces';
+import { type NonNullObject, type Nullish } from '@sapphire/utilities';
+import {
+	ChannelType,
+	ChatInputCommandInteraction,
+	ContextMenuCommandInteraction,
+	type AutocompleteInteraction,
+	type PermissionResolvable,
+	type Snowflake
+} from 'discord.js';
+import type { Command } from '../structures/Command';
+import type { ApplicationCommandRegistry } from '../utils/application-commands/ApplicationCommandRegistry';
+import { PreconditionContainerArray, type PreconditionEntryResolvable } from '../utils/preconditions/PreconditionContainerArray';
+import { type FlagStrategyOptions } from '../utils/strategies/FlagUnorderedStrategy';
+import { BucketScope, CommandOptionsRunTypeEnum } from './Enums';
+
+export type DetailedDescriptionCommand = string | DetailedDescriptionCommandObject;
+
+export interface DetailedDescriptionCommandObject extends NonNullObject {}
+
+/**
+ * The allowed values for {@link Command.Options.runIn}.
+ * @remark It is discouraged to use this type, we recommend using {@link CommandOptionsRunTypeEnum} instead.
+ * @since 2.0.0
+ */
+export type CommandOptionsRunType =
+	| 'DM'
+	| 'GUILD_TEXT'
+	| 'GUILD_VOICE'
+	| 'GUILD_NEWS'
+	| 'GUILD_NEWS_THREAD'
+	| 'GUILD_PUBLIC_THREAD'
+	| 'GUILD_PRIVATE_THREAD'
+	| 'GUILD_ANY';
+
+/**
+ * The allowed values for {@link CommandOptions.runIn}.
+ * @since 4.7.0
+ */
+export type CommandRunInUnion =
+	| ChannelType
+	| Command.RunInTypes
+	| CommandOptionsRunTypeEnum
+	| readonly (ChannelType | Command.RunInTypes | CommandOptionsRunTypeEnum)[]
+	| Nullish;
+
+/**
+ * A more detailed structure for {@link CommandOptions.runIn} when you want to have a different `runIn` for each
+ * command type.
+ * @since 4.7.0
+ */
+export interface CommandSpecificRunIn {
+	chatInputRun?: CommandRunInUnion;
+	messageRun?: CommandRunInUnion;
+	contextMenuRun?: CommandRunInUnion;
+}
+
+/**
+ * The {@link Command} options.
+ * @since 1.0.0
+ */
+export interface CommandOptions extends AliasPiece.Options, FlagStrategyOptions {
+	/**
+	 * Whether to add aliases for commands with dashes in them
+	 * @since 1.0.0
+	 * @default false
+	 */
+	generateDashLessAliases?: boolean;
+
+	/**
+	 * Whether to add aliases for commands with underscores in them
+	 * @since 3.0.0
+	 * @default false
+	 */
+	generateUnderscoreLessAliases?: boolean;
+
+	/**
+	 * The description for the command.
+	 * @since 1.0.0
+	 * @default ''
+	 */
+	description?: string;
+
+	/**
+	 * The detailed description for the command.
+	 * @since 1.0.0
+	 * @default ''
+	 */
+	detailedDescription?: DetailedDescriptionCommand;
+
+	/**
+	 * The full category path for the command
+	 * @since 2.0.0
+	 * @default 'An array of folder names that lead back to the folder that is registered for in the commands store'
+	 * @example
+	 * ```typescript
+	 * // Given a file named `ping.js` at the path of `commands/General/ping.js`
+	 * ['General']
+	 *
+	 * // Given a file named `info.js` at the path of `commands/General/About/ping.js`
+	 * ['General', 'About']
+	 * ```
+	 */
+	fullCategory?: string[];
+
+	/**
+	 * The {@link Precondition}s to be run, accepts an array of their names.
+	 * @seealso {@link PreconditionContainerArray}
+	 * @since 1.0.0
+	 * @default []
+	 */
+	preconditions?: readonly PreconditionEntryResolvable[];
+
+	/**
+	 * The quotes accepted by this command, pass `[]` to disable them.
+	 * @since 1.0.0
+	 * @default
+	 * [
+	 *   ['"', '"'], // Double quotes
+	 *   ['“', '”'], // Fancy quotes (on iOS)
+	 *   ['「', '」'] // Corner brackets (CJK)
+	 *   ['«', '»'] // French quotes (guillemets)
+	 * ]
+	 */
+	quotes?: [string, string][];
+
+	/**
+	 * Sets whether the command should be treated as NSFW. If set to true, the `NSFW` precondition will be added to the list.
+	 * @since 2.0.0
+	 * @default false
+	 */
+	nsfw?: boolean;
+
+	/**
+	 * The amount of entries the cooldown can have before filling up, if set to a non-zero value alongside {@link Command.Options.cooldownDelay}, the `Cooldown` precondition will be added to the list.
+	 * @since 2.0.0
+	 * @default 1
+	 */
+	cooldownLimit?: number;
+
+	/**
+	 * The time in milliseconds for the cooldown entries to reset, if set to a non-zero value alongside {@link Command.Options.cooldownLimit}, the `Cooldown` precondition will be added to the list.
+	 * @since 2.0.0
+	 * @default 0
+	 */
+	cooldownDelay?: number;
+
+	/**
+	 * The scope of the cooldown entries.
+	 * @since 2.0.0
+	 * @default BucketScope.User
+	 */
+	cooldownScope?: BucketScope;
+
+	/**
+	 * The users that are exempt from the Cooldown precondition.
+	 * Use this to filter out someone like a bot owner
+	 * @since 2.0.0
+	 * @default undefined
+	 */
+	cooldownFilteredUsers?: Snowflake[];
+
+	/**
+	 * The required permissions for the client.
+	 * @since 2.0.0
+	 * @default 0
+	 */
+	requiredClientPermissions?: PermissionResolvable;
+
+	/**
+	 * The required permissions for the user.
+	 * @since 2.0.0
+	 * @default 0
+	 */
+	requiredUserPermissions?: PermissionResolvable;
+
+	/**
+	 * The channels the command should run in. If set to `null`, no precondition entry will be added.
+	 * Some optimizations are applied when given an array to reduce the amount of preconditions run
+	 * (e.g. `'GUILD_TEXT'` and `'GUILD_NEWS'` becomes `'GUILD_ANY'`, and if both `'DM'` and `'GUILD_ANY'` are defined,
+	 * then no precondition entry is added as it runs in all channels).
+	 *
+	 * This can be both {@link CommandRunInUnion} which will have the same precondition apply to all the types of commands,
+	 * or you can use {@link CommandSpecificRunIn} to apply different preconditions to different types of commands.
+	 * @since 2.0.0
+	 * @default null
+	 */
+	runIn?: CommandRunInUnion | CommandSpecificRunIn;
+
+	/**
+	 * If {@link SapphireClient.typing} is true, this option will override it.
+	 * Otherwise, this option has no effect - you may call {@link Channel#sendTyping}` in the run method if you want specific commands to display the typing status.
+	 * @default true
+	 */
+	typing?: boolean;
+}
+
+export interface MessageCommandContext extends Record<PropertyKey, unknown> {
+	/**
+	 * The prefix used to run this command.
+	 *
+	 * This is a string for the mention and default prefix, and a RegExp for the `regexPrefix`.
+	 */
+	prefix: string | RegExp;
+	/**
+	 * The alias used to run this command.
+	 */
+	commandName: string;
+	/**
+	 * The matched prefix, this will always be the same as {@link MessageCommand.RunContext.prefix} if it was a string, otherwise it is
+	 * the result of doing `prefix.exec(content)[0]`.
+	 */
+	commandPrefix: string;
+}
+
+export interface ChatInputCommandContext extends Record<PropertyKey, unknown> {
+	/**
+	 * The name of the command.
+	 */
+	commandName: string;
+	/**
+	 * The id of the command.
+	 */
+	commandId: string;
+}
+
+export interface ContextMenuCommandContext extends Record<PropertyKey, unknown> {
+	/**
+	 * The name of the command.
+	 */
+	commandName: string;
+	/**
+	 * The id of the command.
+	 */
+	commandId: string;
+}
+
+export interface AutocompleteCommandContext extends Record<PropertyKey, unknown> {
+	/**
+	 * The name of the command.
+	 */
+	commandName: string;
+	/**
+	 * The id of the command.
+	 */
+	commandId: string;
+}
+
+export interface CommandJSON extends AliasPieceJSON {
+	description: string;
+	detailedDescription: DetailedDescriptionCommand;
+	category: string | null;
+}
+
+export type AutocompleteCommand = Command & Required<Pick<Command, 'autocompleteRun'>>;
+
+export namespace AutocompleteCommand {
+	export type Options = CommandOptions;
+	export type JSON = CommandJSON;
+	export type Context = AliasPiece.Context;
+	export type RunInTypes = CommandOptionsRunType;
+	export type RunContext = AutocompleteCommandContext;
+	export type Interaction<Cached extends import('discord.js').CacheType = import('discord.js').CacheType> = AutocompleteInteraction<Cached>;
+	export type Registry = ApplicationCommandRegistry;
+}
+
+export type ContextMenuCommand = Command & Required<Pick<Command, 'contextMenuRun'>>;
+
+export namespace ContextMenuCommand {
+	export type Options = CommandOptions;
+	export type JSON = CommandJSON;
+	export type Context = AliasPiece.Context;
+	export type RunInTypes = CommandOptionsRunType;
+	export type RunContext = ContextMenuCommandContext;
+	export type Interaction<Cached extends import('discord.js').CacheType = import('discord.js').CacheType> = ContextMenuCommandInteraction<Cached>;
+	export type Registry = ApplicationCommandRegistry;
+}
+
+export type MessageCommand = Command & Required<Pick<Command, 'messageRun'>>;
+
+export namespace MessageCommand {
+	export type Options = CommandOptions;
+	export type JSON = CommandJSON;
+	export type Context = AliasPiece.Context;
+	export type RunInTypes = CommandOptionsRunType;
+	export type RunContext = MessageCommandContext;
+}
+
+export type ChatInputCommand = Command & Required<Pick<Command, 'chatInputRun'>>;
+
+export namespace ChatInputCommand {
+	export type Options = CommandOptions;
+	export type JSON = CommandJSON;
+	export type Context = AliasPiece.Context;
+	export type RunInTypes = CommandOptionsRunType;
+	export type RunContext = ChatInputCommandContext;
+	export type Interaction<Cached extends import('discord.js').CacheType = import('discord.js').CacheType> = ChatInputCommandInteraction<Cached>;
+	export type Registry = ApplicationCommandRegistry;
+}

--- a/src/lib/types/CommandTypes.ts
+++ b/src/lib/types/CommandTypes.ts
@@ -19,7 +19,7 @@ export type DetailedDescriptionCommand = string | DetailedDescriptionCommandObje
 export interface DetailedDescriptionCommandObject extends NonNullObject {}
 
 /**
- * The allowed values for {@link Command.Options.runIn}.
+ * The allowed values for {@link CommandOptions.runIn}.
  * @remark It is discouraged to use this type, we recommend using {@link CommandOptionsRunTypeEnum} instead.
  * @since 2.0.0
  */
@@ -132,14 +132,14 @@ export interface CommandOptions extends AliasPiece.Options, FlagStrategyOptions 
 	nsfw?: boolean;
 
 	/**
-	 * The amount of entries the cooldown can have before filling up, if set to a non-zero value alongside {@link Command.Options.cooldownDelay}, the `Cooldown` precondition will be added to the list.
+	 * The amount of entries the cooldown can have before filling up, if set to a non-zero value alongside {@link CommandOptions.cooldownDelay}, the `Cooldown` precondition will be added to the list.
 	 * @since 2.0.0
 	 * @default 1
 	 */
 	cooldownLimit?: number;
 
 	/**
-	 * The time in milliseconds for the cooldown entries to reset, if set to a non-zero value alongside {@link Command.Options.cooldownLimit}, the `Cooldown` precondition will be added to the list.
+	 * The time in milliseconds for the cooldown entries to reset, if set to a non-zero value alongside {@link CommandOptions.cooldownLimit}, the `Cooldown` precondition will be added to the list.
 	 * @since 2.0.0
 	 * @default 0
 	 */

--- a/src/lib/types/Enums.ts
+++ b/src/lib/types/Enums.ts
@@ -62,3 +62,48 @@ export enum InternalRegistryAPIType {
 	ChatInput,
 	ContextMenu
 }
+
+/**
+ * The allowed values for {@link Command.Options.runIn} as an enum.
+ * @since 2.0.0
+ */
+export enum CommandOptionsRunTypeEnum {
+	Dm = 'DM',
+	GuildText = 'GUILD_TEXT',
+	GuildVoice = 'GUILD_VOICE',
+	GuildNews = 'GUILD_NEWS',
+	GuildNewsThread = 'GUILD_NEWS_THREAD',
+	GuildPublicThread = 'GUILD_PUBLIC_THREAD',
+	GuildPrivateThread = 'GUILD_PRIVATE_THREAD',
+	GuildAny = 'GUILD_ANY'
+}
+
+/**
+ * The available command pre-conditions.
+ * @since 2.0.0
+ */
+export enum CommandPreConditions {
+	Cooldown = 'Cooldown',
+	/** @deprecated Use {@link RunIn} instead. */
+	DirectMessageOnly = 'DMOnly',
+	RunIn = 'RunIn',
+	/** @deprecated Use {@link RunIn} instead. */
+	GuildNewsOnly = 'GuildNewsOnly',
+	/** @deprecated Use {@link RunIn} instead. */
+	GuildNewsThreadOnly = 'GuildNewsThreadOnly',
+	/** @deprecated Use {@link RunIn} instead. */
+	GuildOnly = 'GuildOnly',
+	/** @deprecated Use {@link RunIn} instead. */
+	GuildPrivateThreadOnly = 'GuildPrivateThreadOnly',
+	/** @deprecated Use {@link RunIn} instead. */
+	GuildPublicThreadOnly = 'GuildPublicThreadOnly',
+	/** @deprecated Use {@link RunIn} instead. */
+	GuildTextOnly = 'GuildTextOnly',
+	/** @deprecated Use {@link RunIn} instead. */
+	GuildVoiceOnly = 'GuildVoiceOnly',
+	/** @deprecated Use {@link RunIn} instead. */
+	GuildThreadOnly = 'GuildThreadOnly',
+	NotSafeForWork = 'NSFW',
+	ClientPermissions = 'ClientPermissions',
+	UserPermissions = 'UserPermissions'
+}

--- a/src/lib/types/Enums.ts
+++ b/src/lib/types/Enums.ts
@@ -64,7 +64,7 @@ export enum InternalRegistryAPIType {
 }
 
 /**
- * The allowed values for {@link Command.Options.runIn} as an enum.
+ * The allowed values for {@link CommandOptions.runIn} as an enum.
  * @since 2.0.0
  */
 export enum CommandOptionsRunTypeEnum {

--- a/src/lib/types/Events.ts
+++ b/src/lib/types/Events.ts
@@ -9,18 +9,18 @@ import {
 	type Message
 } from 'discord.js';
 import type { UserError } from '../errors/UserError';
+import type { Command } from '../structures/Command';
+import type { InteractionHandler } from '../structures/InteractionHandler';
+import type { Listener } from '../structures/Listener';
 import type {
 	AutocompleteCommand,
 	AutocompleteCommandContext,
 	ChatInputCommand,
 	ChatInputCommandContext,
-	Command,
 	ContextMenuCommand,
 	ContextMenuCommandContext,
 	MessageCommand
-} from '../structures/Command';
-import type { InteractionHandler } from '../structures/InteractionHandler';
-import type { Listener } from '../structures/Listener';
+} from '../types/CommandTypes';
 import type { ApplicationCommandRegistry } from '../utils/application-commands/ApplicationCommandRegistry';
 import type { PluginHook } from './Enums';
 

--- a/src/lib/utils/preconditions/PreconditionContainerArray.ts
+++ b/src/lib/utils/preconditions/PreconditionContainerArray.ts
@@ -1,9 +1,6 @@
 import { Collection, type ChatInputCommandInteraction, type ContextMenuCommandInteraction, type Message } from 'discord.js';
-import type { ChatInputCommand, ContextMenuCommand, MessageCommand } from '../../structures/Command';
 import type { PreconditionContext, PreconditionKeys, SimplePreconditionKeys } from '../../structures/Precondition';
-import type { IPreconditionCondition } from './conditions/IPreconditionCondition';
-import { PreconditionConditionAnd } from './conditions/PreconditionConditionAnd';
-import { PreconditionConditionOr } from './conditions/PreconditionConditionOr';
+import type { ChatInputCommand, ContextMenuCommand, MessageCommand } from '../../types/CommandTypes';
 import type { IPreconditionContainer, PreconditionContainerReturn } from './IPreconditionContainer';
 import {
 	PreconditionContainerSingle,
@@ -11,6 +8,9 @@ import {
 	type PreconditionSingleResolvableDetails,
 	type SimplePreconditionSingleResolvableDetails
 } from './PreconditionContainerSingle';
+import type { IPreconditionCondition } from './conditions/IPreconditionCondition';
+import { PreconditionConditionAnd } from './conditions/PreconditionConditionAnd';
+import { PreconditionConditionOr } from './conditions/PreconditionConditionOr';
 
 /**
  * The run mode for a {@link PreconditionContainerArray}.

--- a/src/lib/utils/preconditions/PreconditionContainerSingle.ts
+++ b/src/lib/utils/preconditions/PreconditionContainerSingle.ts
@@ -3,8 +3,8 @@ import { err } from '@sapphire/result';
 import type { ChatInputCommandInteraction, ContextMenuCommandInteraction, Message } from 'discord.js';
 import { Identifiers } from '../../errors/Identifiers';
 import { UserError } from '../../errors/UserError';
-import type { ChatInputCommand, ContextMenuCommand, MessageCommand } from '../../structures/Command';
 import type { Precondition, PreconditionContext, PreconditionKeys, Preconditions, SimplePreconditionKeys } from '../../structures/Precondition';
+import type { ChatInputCommand, ContextMenuCommand, MessageCommand } from '../../types/CommandTypes';
 import type { IPreconditionContainer } from './IPreconditionContainer';
 
 /**

--- a/src/lib/utils/preconditions/conditions/IPreconditionCondition.ts
+++ b/src/lib/utils/preconditions/conditions/IPreconditionCondition.ts
@@ -1,6 +1,6 @@
 import type { ChatInputCommandInteraction, ContextMenuCommandInteraction, Message } from 'discord.js';
-import type { ChatInputCommand, ContextMenuCommand, MessageCommand } from '../../../structures/Command';
 import type { PreconditionContext } from '../../../structures/Precondition';
+import type { ChatInputCommand, ContextMenuCommand, MessageCommand } from '../../../types/CommandTypes';
 import type { IPreconditionContainer, PreconditionContainerReturn } from '../IPreconditionContainer';
 
 /**

--- a/src/listeners/application-commands/CorePossibleAutocompleteInteraction.ts
+++ b/src/listeners/application-commands/CorePossibleAutocompleteInteraction.ts
@@ -1,6 +1,6 @@
 import type { AutocompleteInteraction } from 'discord.js';
-import type { AutocompleteCommand } from '../../lib/structures/Command';
 import { Listener } from '../../lib/structures/Listener';
+import type { AutocompleteCommand } from '../../lib/types/CommandTypes';
 import { Events } from '../../lib/types/Events';
 
 export class CoreListener extends Listener<typeof Events.PossibleAutocompleteInteraction> {

--- a/src/listeners/application-commands/chat-input/CorePossibleChatInputCommand.ts
+++ b/src/listeners/application-commands/chat-input/CorePossibleChatInputCommand.ts
@@ -1,6 +1,6 @@
 import type { ChatInputCommandInteraction } from 'discord.js';
-import type { ChatInputCommand } from '../../../lib/structures/Command';
 import { Listener } from '../../../lib/structures/Listener';
+import type { ChatInputCommand } from '../../../lib/types/CommandTypes';
 import { Events } from '../../../lib/types/Events';
 
 export class CoreListener extends Listener<typeof Events.PossibleChatInputCommand> {

--- a/src/listeners/application-commands/context-menu/CorePossibleContextMenuCommand.ts
+++ b/src/listeners/application-commands/context-menu/CorePossibleContextMenuCommand.ts
@@ -1,6 +1,6 @@
 import type { ContextMenuCommandInteraction } from 'discord.js';
-import type { ContextMenuCommand } from '../../../lib/structures/Command';
 import { Listener } from '../../../lib/structures/Listener';
+import type { ContextMenuCommand } from '../../../lib/types/CommandTypes';
 import { Events } from '../../../lib/types/Events';
 
 export class CoreListener extends Listener<typeof Events.PossibleContextMenuCommand> {

--- a/src/optional-listeners/message-command-listeners/CoreMessageCommandTyping.ts
+++ b/src/optional-listeners/message-command-listeners/CoreMessageCommandTyping.ts
@@ -1,7 +1,7 @@
 import { isStageChannel } from '@sapphire/discord.js-utilities';
 import type { Message } from 'discord.js';
-import type { MessageCommand } from '../../lib/structures/Command';
 import { Listener } from '../../lib/structures/Listener';
+import type { MessageCommand } from '../../lib/types/CommandTypes';
 import { Events, type MessageCommandRunPayload } from '../../lib/types/Events';
 
 export class CoreListener extends Listener<typeof Events.MessageCommandRun> {

--- a/src/optional-listeners/message-command-listeners/CorePrefixedMessage.ts
+++ b/src/optional-listeners/message-command-listeners/CorePrefixedMessage.ts
@@ -1,6 +1,6 @@
 import type { Message } from 'discord.js';
-import type { MessageCommand } from '../../lib/structures/Command';
 import { Listener } from '../../lib/structures/Listener';
+import type { MessageCommand } from '../../lib/types/CommandTypes';
 import { Events } from '../../lib/types/Events';
 
 export class CoreListener extends Listener<typeof Events.PrefixedMessage> {

--- a/src/preconditions/RunIn.ts
+++ b/src/preconditions/RunIn.ts
@@ -1,7 +1,8 @@
 import type { ChatInputCommandInteraction, ContextMenuCommandInteraction, Message } from 'discord.js';
 import { Identifiers } from '../lib/errors/Identifiers';
-import { Command, type ChatInputCommand, type ContextMenuCommand, type MessageCommand } from '../lib/structures/Command';
+import { Command } from '../lib/structures/Command';
 import { AllFlowsPrecondition, type Preconditions } from '../lib/structures/Precondition';
+import type { ChatInputCommand, ContextMenuCommand, MessageCommand } from '../lib/types/CommandTypes';
 
 export interface RunInPreconditionContext extends AllFlowsPrecondition.Context {
 	types?: Preconditions['RunIn']['types'];


### PR DESCRIPTION
This way the `Command` file is much shorter and easier to navigate