### PR TITLE
fix: convert .js imports to .cjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
 		"concurrently": "^8.2.2",
 		"cz-conventional-changelog": "^3.3.0",
 		"discord.js": "^14.14.1",
-		"esbuild-plugin-file-path-extensions": "^1.0.0",
+		"esbuild-plugin-file-path-extensions": "^2.0.0",
 		"esbuild-plugin-version-injector": "^1.2.1",
 		"eslint": "^8.55.0",
 		"eslint-config-prettier": "^9.1.0",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -12,7 +12,6 @@ const baseOptions: Options = {
 	target: 'es2021',
 	tsconfig: 'src/tsconfig.json',
 	keepNames: true,
-	esbuildPlugins: [esbuildPluginVersionInjector(), esbuildPluginFilePathExtensions()],
 	treeshake: true
 };
 
@@ -22,25 +21,12 @@ export default [
 		outDir: 'dist/cjs',
 		format: 'cjs',
 		outExtension: () => ({ js: '.cjs' }),
-		esbuildPlugins: [
-			{
-				name: 'fix-cjs-imports',
-				setup({ onResolve }) {
-					onResolve({ filter: /.*/ }, (args) => {
-						if (args.importer) {
-							return {
-								path: `${args.path}.cjs`,
-								external: true
-							};
-						}
-					});
-				}
-			}
-		]
+		esbuildPlugins: [esbuildPluginVersionInjector(), esbuildPluginFilePathExtensions({ cjsExtension: 'cjs' })]
 	}),
 	defineConfig({
 		...baseOptions,
 		outDir: 'dist/esm',
-		format: 'esm'
+		format: 'esm',
+		esbuildPlugins: [esbuildPluginVersionInjector(), esbuildPluginFilePathExtensions()]
 	})
 ];

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -21,7 +21,22 @@ export default [
 		...baseOptions,
 		outDir: 'dist/cjs',
 		format: 'cjs',
-		outExtension: () => ({ js: '.cjs' })
+		outExtension: () => ({ js: '.cjs' }),
+		esbuildPlugins: [
+			{
+				name: 'fix-cjs-imports',
+				setup({ onResolve }) {
+					onResolve({ filter: /.js$/ }, (args) => {
+						if (args.importer) {
+							return {
+								path: `${args.path}.cjs`,
+								external: true
+							};
+						}
+					});
+				}
+			}
+		]
 	}),
 	defineConfig({
 		...baseOptions,

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -12,8 +12,8 @@ const baseOptions: Options = {
 	target: 'es2021',
 	tsconfig: 'src/tsconfig.json',
 	keepNames: true,
-	treeshake: true,
-	esbuildPlugins: [esbuildPluginVersionInjector(), esbuildPluginFilePathExtensions()]
+	esbuildPlugins: [esbuildPluginVersionInjector(), esbuildPluginFilePathExtensions()],
+	treeshake: true
 };
 
 export default [

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -26,7 +26,7 @@ export default [
 			{
 				name: 'fix-cjs-imports',
 				setup({ onResolve }) {
-					onResolve({ filter: /.js$/ }, (args) => {
+					onResolve({ filter: /.*/ }, (args) => {
 						if (args.importer) {
 							return {
 								path: `${args.path}.cjs`,

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -12,7 +12,8 @@ const baseOptions: Options = {
 	target: 'es2021',
 	tsconfig: 'src/tsconfig.json',
 	keepNames: true,
-	treeshake: true
+	treeshake: true,
+	esbuildPlugins: [esbuildPluginVersionInjector(), esbuildPluginFilePathExtensions()]
 };
 
 export default [
@@ -20,13 +21,11 @@ export default [
 		...baseOptions,
 		outDir: 'dist/cjs',
 		format: 'cjs',
-		outExtension: () => ({ js: '.cjs' }),
-		esbuildPlugins: [esbuildPluginVersionInjector(), esbuildPluginFilePathExtensions({ cjsExtension: 'cjs' })]
+		outExtension: () => ({ js: '.cjs' })
 	}),
 	defineConfig({
 		...baseOptions,
 		outDir: 'dist/esm',
-		format: 'esm',
-		esbuildPlugins: [esbuildPluginVersionInjector(), esbuildPluginFilePathExtensions()]
+		format: 'esm'
 	})
 ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -512,23 +512,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/eslintrc@npm:^2.1.3":
-  version: 2.1.3
-  resolution: "@eslint/eslintrc@npm:2.1.3"
-  dependencies:
-    ajv: "npm:^6.12.4"
-    debug: "npm:^4.3.2"
-    espree: "npm:^9.6.0"
-    globals: "npm:^13.19.0"
-    ignore: "npm:^5.2.0"
-    import-fresh: "npm:^3.2.1"
-    js-yaml: "npm:^4.1.0"
-    minimatch: "npm:^3.1.2"
-    strip-json-comments: "npm:^3.1.1"
-  checksum: 77b70a89232fe702c2f765b5b92970f5e4224b55363b923238b996c66fcd991504f40d3663c0543ae17d6c5049ab9b07ab90b65d7601e6f25e8bcd4caf69ac75
-  languageName: node
-  linkType: hard
-
 "@eslint/eslintrc@npm:^2.1.4":
   version: 2.1.4
   resolution: "@eslint/eslintrc@npm:2.1.4"
@@ -543,13 +526,6 @@ __metadata:
     minimatch: "npm:^3.1.2"
     strip-json-comments: "npm:^3.1.1"
   checksum: 7a3b14f4b40fc1a22624c3f84d9f467a3d9ea1ca6e9a372116cb92507e485260359465b58e25bcb6c9981b155416b98c9973ad9b796053fd7b3f776a6946bce8
-  languageName: node
-  linkType: hard
-
-"@eslint/js@npm:8.54.0":
-  version: 8.54.0
-  resolution: "@eslint/js@npm:8.54.0"
-  checksum: 4d491ff234cd94b54499428cb3435623270ff8cc59950e13e6e1ac2fa350ec60502dac7bfd4f486523fee65ad7a358034570fe776b81b14dbfe5525d1e26e1d8
   languageName: node
   linkType: hard
 
@@ -973,7 +949,7 @@ __metadata:
     concurrently: "npm:^8.2.2"
     cz-conventional-changelog: "npm:^3.3.0"
     discord.js: "npm:^14.14.1"
-    esbuild-plugin-file-path-extensions: "npm:^1.0.0"
+    esbuild-plugin-file-path-extensions: "npm:^2.0.0"
     esbuild-plugin-version-injector: "npm:^1.2.1"
     eslint: "npm:^8.55.0"
     eslint-config-prettier: "npm:^9.1.0"
@@ -2529,10 +2505,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-plugin-file-path-extensions@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "esbuild-plugin-file-path-extensions@npm:1.0.0"
-  checksum: 2ad4dd22994ed90ef4772120562e370cce65047e6e1e708c478002fff6ca240db86887d1ab5f0b823f20460c1ff97463533ae0e0054296727ee934868a5300d6
+"esbuild-plugin-file-path-extensions@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "esbuild-plugin-file-path-extensions@npm:2.0.0"
+  checksum: 1555a90dd8e32c1df9c1f8897a3f40e77c799224785a2f8972c84cc5224ca8263fdef0501fda8f982bf1c9ed2ad31b8217278f5ff09bb3bed81236206605bac5
   languageName: node
   linkType: hard
 
@@ -2643,18 +2619,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-config-prettier@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "eslint-config-prettier@npm:9.0.0"
-  peerDependencies:
-    eslint: ">=7.0.0"
-  bin:
-    eslint-config-prettier: bin/cli.js
-  checksum: 276b0b5b5b19066962a9ff3a16a553bdad28e1c0a2ea33a1d75d65c0428bb7b37f6e85ac111ebefcc9bdefb544385856dbe6eaeda5279c639e5549c113d27dda
-  languageName: node
-  linkType: hard
-
-"eslint-config-prettier@npm:^9.1.0":
+"eslint-config-prettier@npm:^9.0.0, eslint-config-prettier@npm:^9.1.0":
   version: 9.1.0
   resolution: "eslint-config-prettier@npm:9.1.0"
   peerDependencies:
@@ -2715,55 +2680,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:^8.48.0":
-  version: 8.54.0
-  resolution: "eslint@npm:8.54.0"
-  dependencies:
-    "@eslint-community/eslint-utils": "npm:^4.2.0"
-    "@eslint-community/regexpp": "npm:^4.6.1"
-    "@eslint/eslintrc": "npm:^2.1.3"
-    "@eslint/js": "npm:8.54.0"
-    "@humanwhocodes/config-array": "npm:^0.11.13"
-    "@humanwhocodes/module-importer": "npm:^1.0.1"
-    "@nodelib/fs.walk": "npm:^1.2.8"
-    "@ungap/structured-clone": "npm:^1.2.0"
-    ajv: "npm:^6.12.4"
-    chalk: "npm:^4.0.0"
-    cross-spawn: "npm:^7.0.2"
-    debug: "npm:^4.3.2"
-    doctrine: "npm:^3.0.0"
-    escape-string-regexp: "npm:^4.0.0"
-    eslint-scope: "npm:^7.2.2"
-    eslint-visitor-keys: "npm:^3.4.3"
-    espree: "npm:^9.6.1"
-    esquery: "npm:^1.4.2"
-    esutils: "npm:^2.0.2"
-    fast-deep-equal: "npm:^3.1.3"
-    file-entry-cache: "npm:^6.0.1"
-    find-up: "npm:^5.0.0"
-    glob-parent: "npm:^6.0.2"
-    globals: "npm:^13.19.0"
-    graphemer: "npm:^1.4.0"
-    ignore: "npm:^5.2.0"
-    imurmurhash: "npm:^0.1.4"
-    is-glob: "npm:^4.0.0"
-    is-path-inside: "npm:^3.0.3"
-    js-yaml: "npm:^4.1.0"
-    json-stable-stringify-without-jsonify: "npm:^1.0.1"
-    levn: "npm:^0.4.1"
-    lodash.merge: "npm:^4.6.2"
-    minimatch: "npm:^3.1.2"
-    natural-compare: "npm:^1.4.0"
-    optionator: "npm:^0.9.3"
-    strip-ansi: "npm:^6.0.1"
-    text-table: "npm:^0.2.0"
-  bin:
-    eslint: bin/eslint.js
-  checksum: 379827964fd7885a4d48611a5237cf5c534eff0ad3d0c1a1d6a14d52ac6758f4efdccd924c9bb3a9aa4dc80a3446d48dc49f61733cd5bd5f74419d0240970e7b
-  languageName: node
-  linkType: hard
-
-"eslint@npm:^8.55.0":
+"eslint@npm:^8.48.0, eslint@npm:^8.55.0":
   version: 8.55.0
   resolution: "eslint@npm:8.55.0"
   dependencies:


### PR DESCRIPTION
The files output in `dist/cjs` we're still trying to import the `.js` extension despite tsup only building `.cjs` files. This PR adds an esbuild plugin to the tsup config to convert the import extentions.