### PR TITLE
fix: point ESM entrypoint to CJS build

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 	"exports": {
 		"import": {
 			"types": "./dist/esm/index.d.mts",
-			"default": "./dist/esm/index.mjs"
+			"default": "./dist/cjs/index.cjs"
 		},
 		"require": {
 			"types": "./dist/cjs/index.d.ts",


### PR DESCRIPTION
This solves old plugins importing the CJS version of the framework, causing sapphire's internal pieces to get double loaded (and cause errors)