### PR TITLE
feat!: make ESM properly load ESM endpoint and not masquerade as ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 	"exports": {
 		"import": {
 			"types": "./dist/esm/index.d.mts",
-			"default": "./dist/cjs/index.cjs"
+			"default": "./dist/esm/index.mjs"
 		},
 		"require": {
 			"types": "./dist/cjs/index.d.ts",


### PR DESCRIPTION
BREAKING CHANGE: This ensures that Framework will properly load the files from the dist/esm folder. This is BREAKING to ALL plugins that are not equally updated to load ESM specific files because they will otherwise load the CJS files of @sapphire/framework and every piece will load twice. DO NOT use this version without also updating your plugins! Sapphire plugins have been released alongside this version, third-party plugins will need to be updated by their respective authors!!

If you're curious btw, yes this long breaking change will show up properly in the changelog:
```md
# [5.0.0](https://github.com/sapphiredev/framework/compare/v5.0.0...v5.0.0) - (2023-12-03)

## 🚀 Features

- Make ESM properly load ESM endpoint and not masquerade as ESM ([f900c2a](https://github.com/sapphiredev/framework/commit/f900c2abb54d1e9db3687d6ec0964d4629c5f31f))
  - 💥 **BREAKING CHANGE:** This ensures that Framework will properly load the files
from the dist/esm folder. This is BREAKING to ALL plugins that are not
equally updated to load ESM specific files because they will otherwise
load the CJS files of @sapphire/framework and every piece will load twice.
DO NOT use this version without also updating your plugins! Sapphire plugins
have been released alongside this version, third-party plugins will need
to be updated by their respective authors!!
```

ain't I good 😎 