### PR TITLE
fix: re-export more types from @sapphire/pieces

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -43,13 +43,22 @@ export {
 	Store,
 	StoreRegistry,
 	container,
+	type AliasPieceJSON,
 	type AliasPieceOptions,
-	// eslint-disable-next-line deprecation/deprecation
-	type PieceContext,
+	type Container,
 	type LoaderPieceContext,
+	type PieceContext, // eslint-disable-line deprecation/deprecation
+	type PieceJSON,
+	type PieceLocationJSON,
+	type PieceOf,
 	type PieceOptions,
+	type StoreManagerManuallyRegisteredPiece,
+	type StoreManuallyRegisteredPiece,
+	type StoreOf,
 	type StoreOptions,
-	type StoreRegistryEntries
+	type StoreRegistryEntries,
+	type StoreRegistryKey,
+	type StoreRegistryValue
 } from '@sapphire/pieces';
 export * from '@sapphire/result';
 export type { Awaitable } from '@sapphire/utilities';


### PR DESCRIPTION
Some of these really should've always been there (like `AliesPieceJSON`, and `PieceJSON`) but I noticed this when trying to import `StoreRegistryValue` which is the type of `store` in:
```ts
for (const store of this.container.stores.values()) {

}
```
so previously you couldn't pass `store` into a receiver function as happens in [sapphiredev/examples](https://github.com/sapphiredev/examples/blob/35b99f47932e8d6a337aac3c748b22cdf92e511a/examples/with-tsup/src/listeners/ready.ts#L44-L50) without adding an import from `@sapphire/pieces` when for all other purposes you only need to import from `@sapphire/framework`.