### PR TITLE
docs: fix typo in CommandTypes.ts

### DIFF
--- a/src/lib/types/CommandTypes.ts
+++ b/src/lib/types/CommandTypes.ts
@@ -97,7 +97,7 @@ export interface CommandOptions extends AliasPiece.Options, FlagStrategyOptions 
 	 * // Given a file named `ping.js` at the path of `commands/General/ping.js`
 	 * ['General']
 	 *
-	 * // Given a file named `info.js` at the path of `commands/General/About/ping.js`
+	 * // Given a file named `info.js` at the path of `commands/General/About/info.js`
 	 * ['General', 'About']
 	 * ```
 	 */


### PR DESCRIPTION
This pull request fixes a "typo" in the documentation of the `fullCategory` command option example. The author of the example presumably forgot to change the file name in the path provided in the example, so I went ahead and changed it so two different examples are shown with no confusion.