### PR TITLE
fix(ClientPermissions): check app permissions when used with user apps

### DIFF
--- a/src/preconditions/ClientPermissions.ts
+++ b/src/preconditions/ClientPermissions.ts
@@ -55,6 +55,8 @@ export class CorePrecondition extends AllFlowsPrecondition {
 	): AllFlowsPrecondition.AsyncResult {
 		const required = context.permissions ?? new PermissionsBitField();
 
+		if (!interaction.channel) return this.ok(); // When using user-installable apps channel will be always null
+
 		const channel = await this.fetchChannelFromInteraction(interaction);
 
 		const permissions = await this.getPermissionsForChannel(channel, interaction);
@@ -68,6 +70,8 @@ export class CorePrecondition extends AllFlowsPrecondition {
 		context: PermissionPreconditionContext
 	): AllFlowsPrecondition.AsyncResult {
 		const required = context.permissions ?? new PermissionsBitField();
+
+		if (!interaction.channel) return this.ok(); // When using user-installable apps channel will be always null
 
 		const channel = await this.fetchChannelFromInteraction(interaction);
 


### PR DESCRIPTION
`interaction.channel` will always be null when used with user-installable and since `ClientPermissions` always fetch the invoked interaction channel, it will throw an error causing "The application did not respond"

https://github.com/sapphiredev/framework/blob/7ae8c5bded0237bb5862d244e723a121464bb5cc/src/lib/structures/Precondition.ts#L51-L58

![image](https://github.com/user-attachments/assets/65480630-b084-4918-b3b0-682b01bc2cec)
