### PR TITLE
fix(ClientPermissions): resolve client permissions for older applications

### DIFF
--- a/src/preconditions/ClientPermissions.ts
+++ b/src/preconditions/ClientPermissions.ts
@@ -86,9 +86,9 @@ export class CorePrecondition extends AllFlowsPrecondition {
 				if (isNullish(permissions)) {
 					const me = await messageOrInteraction.guild?.members.fetchMe();
 					if (me) {
-					  permissions = channel.permissionsFor(me);
+						permissions = channel.permissionsFor(me);
 					}
-				  }
+				}
 			}
 		}
 

--- a/src/preconditions/ClientPermissions.ts
+++ b/src/preconditions/ClientPermissions.ts
@@ -83,6 +83,12 @@ export class CorePrecondition extends AllFlowsPrecondition {
 				}
 			} else {
 				permissions = channel.permissionsFor(messageOrInteraction.applicationId);
+				if (isNullish(permissions)) {
+					const me = await messageOrInteraction.guild?.members.fetchMe();
+					if (me) {
+					  permissions = channel.permissionsFor(me);
+					}
+				  }
 			}
 		}
 


### PR DESCRIPTION
In a likely regression of: https://github.com/sapphiredev/framework/pull/616 setting `requiredClientPermissions` in commands is resulting in consistent fallback messages of:
> I was unable to resolve my permissions in the chat input command invocation channel.

By restoring the fix from https://github.com/sapphiredev/framework/pull/616 client permissions no longer error for our application.

🧪Tested on: Node 22, Discord.js: 14.18.0, cjs distribution
