### PR TITLE
fix: sort integration types & contexts before comparing

### DIFF
--- a/src/lib/utils/application-commands/compute-differences/contexts.ts
+++ b/src/lib/utils/application-commands/compute-differences/contexts.ts
@@ -23,24 +23,26 @@ export function* checkInteractionContextTypes(
 	}
 	// 2. Maybe changes in order or additions, log
 	else if (newContexts?.length) {
+		const existingContextSorted = existingContexts?.toSorted() ?? [];
+		const newContextSorted = newContexts?.toSorted() ?? [];
 		let index = 0;
 
-		for (const newContext of newContexts) {
+		for (const newContext of newContextSorted) {
 			const currentIndex = index++;
 
-			if (existingContexts![currentIndex] !== newContext) {
+			if (existingContextSorted[currentIndex] !== newContext) {
 				yield {
 					key: `contexts[${currentIndex}]`,
-					original: `contexts type ${existingContexts?.[currentIndex]}`,
+					original: `contexts type ${existingContextSorted[currentIndex]}`,
 					expected: `contexts type ${newContext}`
 				};
 			}
 		}
 
-		if (index < existingContexts!.length) {
+		if (index < existingContextSorted.length) {
 			let type: InteractionContextType;
 
-			while ((type = existingContexts![index]) !== undefined) {
+			while ((type = existingContextSorted[index]) !== undefined) {
 				yield {
 					key: `contexts[${index}]`,
 					original: `context ${type} present`,

--- a/src/lib/utils/application-commands/compute-differences/contexts.ts
+++ b/src/lib/utils/application-commands/compute-differences/contexts.ts
@@ -23,8 +23,8 @@ export function* checkInteractionContextTypes(
 	}
 	// 2. Maybe changes in order or additions, log
 	else if (newContexts?.length) {
-		const existingContextSorted = existingContexts?.toSorted() ?? [];
-		const newContextSorted = newContexts?.toSorted() ?? [];
+		const existingContextSorted = existingContexts?.toSorted((a, b) => a - b) ?? [];
+		const newContextSorted = newContexts?.toSorted((a, b) => a - b) ?? [];
 		let index = 0;
 
 		for (const newContext of newContextSorted) {

--- a/src/lib/utils/application-commands/compute-differences/integration_types.ts
+++ b/src/lib/utils/application-commands/compute-differences/integration_types.ts
@@ -23,8 +23,8 @@ export function* checkIntegrationTypes(
 	}
 	// 2. Maybe changes in order or additions, log
 	else if (newIntegrationTypes?.length) {
-		const existingIntegrationTypesSorted = existingIntegrationTypes?.toSorted() ?? [];
-		const newIntegrationTypesSorted = newIntegrationTypes?.toSorted() ?? [];
+		const existingIntegrationTypesSorted = existingIntegrationTypes?.toSorted((a, b) => a - b) ?? [];
+		const newIntegrationTypesSorted = newIntegrationTypes?.toSorted((a, b) => a - b) ?? [];
 		let index = 0;
 
 		for (const newIntegrationType of newIntegrationTypesSorted) {

--- a/src/lib/utils/application-commands/compute-differences/integration_types.ts
+++ b/src/lib/utils/application-commands/compute-differences/integration_types.ts
@@ -23,24 +23,26 @@ export function* checkIntegrationTypes(
 	}
 	// 2. Maybe changes in order or additions, log
 	else if (newIntegrationTypes?.length) {
+		const existingIntegrationTypesSorted = existingIntegrationTypes?.toSorted() ?? [];
+		const newIntegrationTypesSorted = newIntegrationTypes?.toSorted() ?? [];
 		let index = 0;
 
-		for (const newIntegrationType of newIntegrationTypes) {
+		for (const newIntegrationType of newIntegrationTypesSorted) {
 			const currentIndex = index++;
 
-			if (existingIntegrationTypes![currentIndex] !== newIntegrationType) {
+			if (existingIntegrationTypesSorted[currentIndex] !== newIntegrationType) {
 				yield {
 					key: `integrationTypes[${currentIndex}]`,
-					original: `integration type ${existingIntegrationTypes?.[currentIndex]}`,
+					original: `integration type ${existingIntegrationTypesSorted[currentIndex]}`,
 					expected: `integration type ${newIntegrationType}`
 				};
 			}
 		}
 
-		if (index < existingIntegrationTypes!.length) {
+		if (index < existingIntegrationTypesSorted.length) {
 			let type: ApplicationIntegrationType;
 
-			while ((type = existingIntegrationTypes![index]) !== undefined) {
+			while ((type = existingIntegrationTypesSorted[index]) !== undefined) {
 				yield {
 					key: `integrationTypes[${index}]`,
 					original: `integration type ${type} present`,

--- a/tests/application-commands/computeDifferences.test.ts
+++ b/tests/application-commands/computeDifferences.test.ts
@@ -1,4 +1,10 @@
-import { ApplicationCommandOptionType, ApplicationCommandType, type RESTPostAPIChatInputApplicationCommandsJSONBody } from 'discord-api-types/v10';
+import {
+	ApplicationCommandOptionType,
+	ApplicationCommandType,
+	ApplicationIntegrationType,
+	InteractionContextType,
+	type RESTPostAPIChatInputApplicationCommandsJSONBody
+} from 'discord-api-types/v10';
 import { ChannelType } from 'discord.js';
 import { getCommandDifferences as getCommandDifferencesRaw } from '../../src/lib/utils/application-commands/computeDifferences';
 
@@ -54,6 +60,44 @@ describe('Compute differences for provided application commands', () => {
 		const command2: RESTPostAPIChatInputApplicationCommandsJSONBody = {
 			description: 'description 1',
 			name: 'command1'
+		};
+
+		expect(getCommandDifferences(command1, command2, false)).toEqual([]);
+	});
+
+	test('GIVEN two commands with the same integration types in a different order THEN do not return any difference', () => {
+		const command1: RESTPostAPIChatInputApplicationCommandsJSONBody = {
+			description: 'description 1',
+			name: 'command1',
+			integration_types: [ApplicationIntegrationType.UserInstall, ApplicationIntegrationType.GuildInstall]
+		};
+
+		const command2: RESTPostAPIChatInputApplicationCommandsJSONBody = {
+			description: 'description 2',
+			name: 'command1',
+			integration_types: [ApplicationIntegrationType.GuildInstall, ApplicationIntegrationType.UserInstall]
+		};
+
+		expect(getCommandDifferences(command1, command2, false)).toEqual([
+			{
+				key: 'description',
+				original: command1.description,
+				expected: command2.description
+			}
+		]);
+	});
+
+	test('GIVEN two commands with the same contexts in a different order THEN do not return any difference', () => {
+		const command1: RESTPostAPIChatInputApplicationCommandsJSONBody = {
+			description: 'description 1',
+			name: 'command1',
+			contexts: [InteractionContextType.PrivateChannel, InteractionContextType.Guild]
+		};
+
+		const command2: RESTPostAPIChatInputApplicationCommandsJSONBody = {
+			description: 'description 1',
+			name: 'command1',
+			contexts: [InteractionContextType.Guild, InteractionContextType.PrivateChannel]
 		};
 
 		expect(getCommandDifferences(command1, command2, false)).toEqual([]);


### PR DESCRIPTION
This PR is basically a slightly simplified version of #866.

As the issue explains this currently causes any chat input command with `contexts` and/or `integration_types` to be diffed incorrectly triggering unnecessary command updates.

Fixes #865